### PR TITLE
Improve parallelization and logging

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,12 +8,13 @@
 preprocessing:
   output_dir: # Path to save features to
   wsi_dir: # Path of where the whole-slide images are.
-  cache_dir: # Directory to store resulting slide JPGs
+  cache_dir: # Directory to store intermediate slide JPGs
   microns: 256 # Edge length in microns for each patch (default is 256, with pixel size 224, 256/224 = ~1.14MPP = ~9x magnification)
   norm: true # Perform Macenko normalisation
   normalization_template: ${oc.env:STAMP_RESOURCES_DIR}/normalization_template.jpg # Path to normalization template
   model_path: ${oc.env:STAMP_RESOURCES_DIR}/ctranspath.pth  # Path of where model for the feature extractor is
   del_slide: false # Remove the original slide after processing
+  cache: true # Save intermediate images (slide, background rejected, normalized)
   only_feature_extraction: false # Only perform feature extraction (intermediate images (background rejected, [normalized]) have to exist)
   cores: 8 # CPU cores to use
   device: cuda:0 # device to run feature extraction on (cpu, cuda, cuda:0, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stamp"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Omar El Nahhas", email="omar.el_nahhas@tu-dresden.de" },
   { name="Marko van Treeck", email="markovantreeck@gmail.com" },
   { name="Georg Wölflein", email="georgw7777@gmail.com" },
   { name="Tim Lenz", email="tim.lenz@tu-dresden.de" },
   { name="Laura Žigutytė", email="laura.zigutyte@tu-dresden.de" },
+  { name="Cornelius Kummer", email="cornelius.kummer@tu-dresden.de" },
 ]
 description = "A protocol for Solid Tumor Associative Modeling in Pathology"
 readme = "README.md"

--- a/stamp/cli.py
+++ b/stamp/cli.py
@@ -87,6 +87,7 @@ def run_cli(args: argparse.Namespace):
                 cores=c.cores,
                 norm=c.norm,
                 del_slide=c.del_slide,
+                cache=c.cache if 'cache' in c else True,
                 only_feature_extraction=c.only_feature_extraction,
                 device=c.device,
                 normalization_template=Path(c.normalization_template)

--- a/stamp/preprocessing/helpers/concurrent_canny_rejection.py
+++ b/stamp/preprocessing/helpers/concurrent_canny_rejection.py
@@ -36,7 +36,7 @@ def canny_fcn(patch: np.array) -> Tuple[np.array, bool]:
         return (patch, False)
 
 
-def reject_background(img: np.array, patch_size: Tuple[int,int], step: int, save_tiles: bool = False, outdir: Path = None, cores: int = 8) -> \
+def reject_background(img: np.array, patch_size: Tuple[int,int], step: int, cores: int = 8) -> \
 Tuple[ndarray, ndarray, List[Any]]:
     img_shape = img.shape
 
@@ -54,7 +54,6 @@ Tuple[ndarray, ndarray, List[Any]]:
         for i in i_range:
             for j in j_range:
                 patch = img[(i*patch_size[0]):(i*patch_size[0]+step), (j*patch_size[1]):(j*patch_size[1]+step)]
-                #(PIL.Image.fromarray(patch)).save(f'{outdir}/patch_{i*len(j_range) + j}.jpg')
                 patches_shapes_list.append(patch.shape)
                 future = executor.submit(canny_fcn, patch)
                 # begin_time_list.append(time.time())

--- a/stamp/preprocessing/helpers/concurrent_canny_rejection.py
+++ b/stamp/preprocessing/helpers/concurrent_canny_rejection.py
@@ -76,5 +76,5 @@ Tuple[ndarray, ndarray, List[Any]]:
 
         end = time.time()
 
-    print(f"\nFinished Canny background rejection, rejected {np.sum(rejected_tile_list)} tiles: {end-begin}")
+    print(f"Finished Canny background rejection, rejected {np.sum(rejected_tile_list)} tiles: {end-begin:.2f} seconds")
     return ordered_patch_list, rejected_tile_list, patches_shapes_list

--- a/stamp/preprocessing/helpers/concurrent_canny_rejection.py
+++ b/stamp/preprocessing/helpers/concurrent_canny_rejection.py
@@ -39,7 +39,6 @@ def canny_fcn(patch: np.array) -> Tuple[np.array, bool]:
 def reject_background(img: np.array, patch_size: Tuple[int,int], step: int, save_tiles: bool = False, outdir: Path = None, cores: int = 8) -> \
 Tuple[ndarray, ndarray, List[Any]]:
     img_shape = img.shape
-    print(f"\nSize of WSI: {img_shape}")
 
     split=True
     x=(img_shape[0]//patch_size[0])*(img_shape[1]//patch_size[1])

--- a/stamp/preprocessing/helpers/feature_extractors.py
+++ b/stamp/preprocessing/helpers/feature_extractors.py
@@ -43,7 +43,7 @@ class FeatureExtractor:
         if torch.cuda.is_available():
             model = model.to(device)
 
-        print("CTransPath model successfully initialised...")
+        print("CTransPath model successfully initialised...\n")
         model_name='xiyuewang-ctranspath-7c998680'
 
         return model, model_name

--- a/stamp/preprocessing/helpers/feature_extractors.py
+++ b/stamp/preprocessing/helpers/feature_extractors.py
@@ -73,7 +73,8 @@ class SlideTileDataset(Dataset):
 def extract_features_(
         *,
         model, model_name, norm_wsi_img: np.ndarray, coords: list, wsi_name: str, outdir: Path,
-        augmented_repetitions: int = 0, cores: int = 8, is_norm: bool = True, device: str = 'cpu'
+        augmented_repetitions: int = 0, cores: int = 8, is_norm: bool = True, device: str = 'cpu',
+        target_microns: int = 256, patch_size: int = 224
 ) -> None:
     """Extracts features from slide tiles.
 
@@ -107,7 +108,10 @@ def extract_features_(
     extractor_string = f'STAMP-extract-{__version__}_{model_name}'
     with open(outdir.parent/'info.json', 'w') as f:
         json.dump({'extractor': extractor_string,
-                  'augmented_repetitions': augmented_repetitions}, f)
+                  'augmented_repetitions': augmented_repetitions,
+                  'normalized': is_norm,
+                  'microns': target_microns,
+                  'patch_size': patch_size}, f)
 
     unaugmented_ds = SlideTileDataset(norm_wsi_img, normal_transform)
     augmented_ds = []

--- a/stamp/preprocessing/helpers/loading_slides.py
+++ b/stamp/preprocessing/helpers/loading_slides.py
@@ -59,7 +59,7 @@ def get_slide_mpp(slide: openslide.OpenSlide) -> float:
             if slide_mpp:
                 print(f"MPP retrieved from comments after initial failure: {slide_mpp}")
             else:
-                print(f"MPP is missing in the metadata of this file format, attempting to extract from metadata...")
+                print(f"MPP is missing in the comments of this file format, attempting to extract from metadata...")
                 slide_mpp = extract_mpp_from_metadata(slide)
                 print(f"MPP re-matched from metadata after initial failure: {slide_mpp}")
         except:
@@ -112,9 +112,8 @@ def process_slide_jpg(slide_jpg: PIL.Image):
     img_norm_wsi_jpg = PIL.Image.open(slide_jpg)
     image_array = np.array(img_norm_wsi_jpg)
     canny_norm_patch_list = []
-    coords_list=[]
-    total=0
-    patch_saved=0
+    coords_list = []
+    total = 0
     for i in range(0, image_array.shape[0]-224, 224):
         for j in range(0, image_array.shape[1]-224, 224):
             total+=1
@@ -122,9 +121,8 @@ def process_slide_jpg(slide_jpg: PIL.Image):
             # if patch is not fully black (i.e. rejected previously)
             if np.sum(patch) > 0:
                 canny_norm_patch_list.append(patch)
-                coords_list.append((i,j))
-                patch_saved+=1
-    return canny_norm_patch_list, coords_list, patch_saved, total
+                coords_list.append((i, j))
+    return canny_norm_patch_list, coords_list, total
 
 
 # test get_raw_tile_list function

--- a/stamp/preprocessing/helpers/loading_slides.py
+++ b/stamp/preprocessing/helpers/loading_slides.py
@@ -1,7 +1,6 @@
 import re
 from typing import Dict, Tuple
 from concurrent import futures
-import logging
 import openslide
 from tqdm import tqdm
 import numpy as np
@@ -60,6 +59,7 @@ def get_slide_mpp(slide: openslide.OpenSlide) -> float:
             if slide_mpp:
                 print(f"MPP retrieved from comments after initial failure: {slide_mpp}")
             else:
+                print(f"MPP is missing in the metadata of this file format, attempting to extract from metadata...")
                 slide_mpp = extract_mpp_from_metadata(slide)
                 print(f"MPP re-matched from metadata after initial failure: {slide_mpp}")
         except:
@@ -67,7 +67,6 @@ def get_slide_mpp(slide: openslide.OpenSlide) -> float:
     return slide_mpp
 
 def extract_mpp_from_metadata(slide: openslide.OpenSlide) -> float:
-    logging.error(f"MPP is missing in the metadata of this file format, attempting to extract from metadata of {slide._filename}")
     import xml.dom.minidom as minidom
     xml_path = slide.properties['tiff.ImageDescription']
     doc = minidom.parseString(xml_path)

--- a/stamp/preprocessing/helpers/loading_slides.py
+++ b/stamp/preprocessing/helpers/loading_slides.py
@@ -67,7 +67,7 @@ def get_slide_mpp(slide: openslide.OpenSlide) -> float:
     return slide_mpp
 
 def extract_mpp_from_metadata(slide: openslide.OpenSlide) -> float:
-    logging.exception("MPP is missing in the metadata of this file format, attempting to extract from metadata...")
+    logging.error(f"MPP is missing in the metadata of this file format, attempting to extract from metadata of {slide._filename}")
     import xml.dom.minidom as minidom
     xml_path = slide.properties['tiff.ImageDescription']
     doc = minidom.parseString(xml_path)

--- a/stamp/preprocessing/helpers/stainNorm_Macenko.py
+++ b/stamp/preprocessing/helpers/stainNorm_Macenko.py
@@ -107,11 +107,11 @@ class Normalizer(object):
         begin = time.time()
         stain_matrix_source = get_stain_matrix(og_img)
         after_sm = time.time()
-        print(f'Get stain matrix: {after_sm-begin} seconds')
+        print(f"Get stain matrix: {after_sm-begin} seconds")
         I_shape = og_img.shape
         source_concentrations_list = ut.get_concentrations_source(bg_rejected_img, I_shape, stain_matrix_source, rejected_list)
         after_conc = time.time()
-        print(f'\nGet concentrations (normalisation): {after_conc-after_sm} seconds')
+        print(f"\nGet concentrations (normalisation): {after_conc-after_sm} seconds")
 
         del og_img, stain_matrix_source
 
@@ -124,20 +124,19 @@ class Normalizer(object):
                 for i, source_concentrations in enumerate(source_concentrations_list):
                     # if all zeroes, skip
                     if np.any(source_concentrations):
-                        future = executor.submit(
-                        concurrent_concXstain, self, source_concentrations=source_concentrations, patch_shapes=patch_shapes, idx=i)
+                        future = executor.submit(concurrent_concXstain, self, source_concentrations=source_concentrations, patch_shapes=patch_shapes, idx=i)
                         future_coords[future] = i
                 
                 norm_img_patches_list = np.zeros((len(source_concentrations_list), 224, 224, 3), dtype=np.uint8)
-                for tile_future in tqdm(futures.as_completed(future_coords), total=len(source_concentrations_list)-len(rejected_list), desc='Concentrations x Stain', leave=False):
+                for tile_future in tqdm(futures.as_completed(future_coords), total=len(source_concentrations_list)-len(rejected_list), desc="Concentrations x Stain", leave=False):
                     i = future_coords[tile_future]
                     patch = tile_future.result()
                     norm_img_patches_list[i] = patch
                 
             after_transform = time.time()
-            print(f'\nConcentrations x Stain matrix: {after_transform-after_conc} seconds')
+            print(f"\nConcentrations x Stain matrix: {after_transform-after_conc} seconds")
 
-            print('Reconstructing image from patches...')
+            print("Reconstructing image from patches...")
             norm_output_array = []
             canny_output_array = []
             for i in range(len(norm_img_patches_list)):
@@ -181,7 +180,7 @@ class Normalizer(object):
             maxC_target = np.percentile(self.target_concentrations, 99, axis=0).reshape((1, 2))
             jit_output = transform_return(source_concentrations_list, self.stain_matrix_target, maxC_target, maxC_source, I_shape) #I_shape, @3 (removed)
             after_transform = time.time()
-            print(f'Concentrations x Stain matrix: {after_transform-after_conc} seconds')
+            print(f"Concentrations x Stain matrix: {after_transform-after_conc} seconds")
             output_img = Image.fromarray(np.array(jit_output))
             output_array = jit_output
             coords_list = None #TODO
@@ -204,7 +203,7 @@ class Normalizer(object):
 
 #test get_stain_matrix
 def test_get_stain_matrix():
-    img = Image.open('test_images/1.jpg')
+    img = Image.open("test_images/1.jpg")
     img = np.array(img)
     img = ut.standardize_brightness(img)
     stain_matrix = get_stain_matrix(img)

--- a/stamp/preprocessing/helpers/stainNorm_Macenko.py
+++ b/stamp/preprocessing/helpers/stainNorm_Macenko.py
@@ -107,11 +107,11 @@ class Normalizer(object):
         begin = time.time()
         stain_matrix_source = get_stain_matrix(og_img)
         after_sm = time.time()
-        print(f'Get stain matrix: {after_sm-begin}')
+        print(f'Get stain matrix: {after_sm-begin} seconds')
         I_shape = og_img.shape
         source_concentrations_list = ut.get_concentrations_source(bg_rejected_img, I_shape, stain_matrix_source, rejected_list)
         after_conc = time.time()
-        print(f'\nGet concentrations (normalisation): {after_conc-after_sm}')
+        print(f'\nGet concentrations (normalisation): {after_conc-after_sm} seconds')
 
         del og_img, stain_matrix_source
 
@@ -135,7 +135,7 @@ class Normalizer(object):
                     norm_img_patches_list[i] = patch
                 
             after_transform = time.time()
-            print(f'Concentrations x Stain matrix: {after_transform-after_conc}')
+            print(f'\nConcentrations x Stain matrix: {after_transform-after_conc} seconds')
 
             print('Reconstructing image from patches...')
             norm_output_array = []
@@ -181,7 +181,7 @@ class Normalizer(object):
             maxC_target = np.percentile(self.target_concentrations, 99, axis=0).reshape((1, 2))
             jit_output = transform_return(source_concentrations_list, self.stain_matrix_target, maxC_target, maxC_source, I_shape) #I_shape, @3 (removed)
             after_transform = time.time()
-            print(f'Concentrations x Stain matrix: {after_transform-after_conc}')
+            print(f'Concentrations x Stain matrix: {after_transform-after_conc} seconds')
             output_img = Image.fromarray(np.array(jit_output))
             output_array = jit_output
             coords_list = None #TODO

--- a/stamp/preprocessing/helpers/stain_utils.py
+++ b/stamp/preprocessing/helpers/stain_utils.py
@@ -259,7 +259,6 @@ def get_concentrations_source(I, I_shape, stain_matrix, rejection_list, lamda=0.
     # patchify returns a NumPy array with shape (n_rows, n_cols, 1, H, W, N), if image is N-channels.
     # H W N is Height Width N-channels of the extracted patch
     # n_rows is the number of patches for each column and n_cols is the number of patches for each row
-    print(f"\nSize of WSI: {I_shape}")
 
     if True: #(I_shape[0] + I_shape[1]) > (224*2): #bigger than 30k edge pixels combined, i.e. 15k x 15k
         #x = 500 # 2 for largest possible blocks

--- a/stamp/preprocessing/helpers/swin_transformer.py
+++ b/stamp/preprocessing/helpers/swin_transformer.py
@@ -357,7 +357,8 @@ class WindowAttention(nn.Module):
         # get pair-wise relative position index for each token inside the window
         coords_h = torch.arange(self.window_size[0])
         coords_w = torch.arange(self.window_size[1])
-        coords = torch.stack(torch.meshgrid([coords_h, coords_w]))  # 2, Wh, Ww
+        # Added indexing argument to torch.meshgrid to avoid deprecation warning
+        coords = torch.stack(torch.meshgrid([coords_h, coords_w], indexing='ij'))  # 2, Wh, Ww
         coords_flatten = torch.flatten(coords, 1)  # 2, Wh*Ww
         relative_coords = coords_flatten[:, :, None] - coords_flatten[:, None, :]  # 2, Wh*Ww, Wh*Ww
         relative_coords = relative_coords.permute(1, 2, 0).contiguous()  # Wh*Ww, Wh*Ww, 2

--- a/stamp/preprocessing/helpers/swin_transformer.py
+++ b/stamp/preprocessing/helpers/swin_transformer.py
@@ -17,7 +17,6 @@ model.load_state_dict(td['model'], strict=True)
 
 import sys
 import math
-import logging
 import collections.abc
 
 from copy import deepcopy

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -36,7 +36,8 @@ def lock_file(slide_url):
     try:
         yield
     finally:
-        os.remove(f'{str(slide_url)}.tmp')
+        if os.path.exists(f'{slide_url}.tmp'): # Catch collision cases
+            os.remove(f'{str(slide_url)}.tmp')
 
 def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Path,
                norm: bool, del_slide: bool, only_feature_extraction: bool, 

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -195,36 +195,3 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                 os.remove(str(slide_url))
 
     print(f"===== End-to-end processing time of {len(img_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} =====")
-
-def main():
-    parser = argparse.ArgumentParser(
-        description='Normalise WSI directly.')
-
-    parser.add_argument('-o', '--output-dir', type=Path, required=True,
-                        help='Path to save features to.')
-    parser.add_argument('--wsi-dir', metavar='DIR', type=Path, required=True,
-                        help='Path of where the whole-slide images are.')
-    parser.add_argument('-m', '--model', metavar='DIR', type=Path, required=True,
-                        help='Path of where model for the feature extractor is.')
-    parser.add_argument('--cache-dir', type=Path, required=True, default=None,
-        help='Directory to store resulting slide JPGs.')
-    
-    parser.add_argument('--patch-size', type=int, default=224,
-                        help='Size of the square patch to tessellate.')
-    parser.add_argument('--mpp', type=float, default=256/224,
-                    help='Microns-per-pixel value for slide resolution.')
-    parser.add_argument('-c', '--cores', type=int, default=8,
-                    help='CPU cores to use, 8 default.')
-    parser.add_argument('-n','--norm', action='store_true')
-    parser.add_argument('--no-norm', dest='norm', action='store_false')
-    parser.set_defaults(norm=True)
-    parser.add_argument('-d', '--del-slide', action='store_true', default=False,
-                         help='Removing the original slide after processing.')
-    parser.add_argument('--only-fex', action='store_true', default=False)
-
-    args = parser.parse_args()
-    preprocess(output_dir=args.output_dir, wsi_dir=args.wsi_dir, model_path=args.model, cache_dir=args.cache_dir, patch_size=args.patch_size, target_mpp=args.mpp, cores=args.cores, norm=args.norm, del_slide=args.del_slide, only_feature_extraction=args.only_fex)
-
-
-if __name__ == '__main__':
-    main()

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -188,7 +188,9 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                 start_time = time.time()
                 if len(canny_norm_patch_list) > 0:
                     extract_features_(model=model, model_name=model_name, norm_wsi_img=canny_norm_patch_list,
-                                    coords=coords_list, wsi_name=slide_name, outdir=feat_out_dir, cores=cores, is_norm=norm, device=device if has_gpu else "cpu")
+                                    coords=coords_list, wsi_name=slide_name, outdir=feat_out_dir, cores=cores,
+                                    is_norm=norm, device=device if has_gpu else "cpu", target_microns=target_microns,
+                                    patch_size=patch_size)
                     logging.info(f"Extracted features from slide: {time.time() - start_time:.2f} seconds ({len(canny_norm_patch_list)} tiles)")
                     num_processed += 1
                 else:

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -113,22 +113,26 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
     total_start_time = time.time()
 
     img_name = "norm_slide.jpg" if norm else "canny_slide.jpg"
-    existing_features = [f.stem for f in output_file_dir.glob("**/*.h5")] if output_file_dir.exists() else []
+    # Get list of slides, filter out slides that have already been processed
+    existing = [f.stem for f in output_file_dir.glob("**/*.h5")] if output_file_dir.exists() else []
     if not only_feature_extraction:
-        img_dir = [
-            svs for ext in supported_extensions for svs in wsi_dir.glob(f"**/*{ext}") if svs.stem not in existing_features
-        ]
+        img_dir = [svs for ext in supported_extensions for svs in wsi_dir.glob(f"**/*{ext}")]
+        existing = [f for f in existing if f in [f.stem for f in img_dir]]
+        img_dir = [f for f in img_dir if f.stem not in existing]
     else:
         if not cache_dir.exists():
             logging.error("Cache directory does not exist, cannot extract features from cached slides!")
             exit(1)
-        img_dir = [jpg for jpg in cache_dir.glob(f"**/*/{img_name}") if jpg.parent.name not in existing_features]
+        img_dir = [jpg for jpg in cache_dir.glob(f"**/*/{img_name}")]
+        existing = [f for f in existing if f in [f.parent.name for f in img_dir]]
+        img_dir = [f for f in img_dir if f.parent.name not in existing]
 
     shuffle(img_dir)
+    num_total = len(img_dir) + len(existing)
     num_processed = 0
     error_slides = []
-    if len(existing_features):
-        print(f"\nFound {len(existing_features)} existing feature files, skipping these slides...")
+    if len(existing):
+        print(f"\n For {len(existing)} out of {num_total} slides in the wsi directory feature files were found, skipping these slides...")
     for slide_url in tqdm(img_dir, "\nPreprocessing progress", leave=False, miniters=1, mininterval=0):
         slide_name = slide_url.stem if not only_feature_extraction else slide_url.parent.name
         slide_cache_dir = cache_dir/slide_name
@@ -233,13 +237,13 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                 logging.info(".h5 file for this slide already exists. Skipping...")
             else:
                 logging.info("Slide is already being processed. Skipping...")
-            existing_features.append(slide_name)
+            existing.append(slide_name)
             if del_slide:
                 print("Deleting slide from local folder...")
                 if os.path.exists(slide_url):
                     os.remove(slide_url)
 
-    logging.info(f"===== End-to-end processing time of {len(img_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} =====")
-    logging.info(f"Summary: Processed {num_processed} slides, encountered {len(error_slides)} errors, skipped {len(existing_features)} readily-processed slides")
+    logging.info(f"===== End-to-end processing time of {num_total} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} =====")
+    logging.info(f"Summary: Processed {num_processed} slides, encountered {len(error_slides)} errors, skipped {len(existing)} readily-processed slides")
     if len(error_slides):
         logging.info("The following slides were not processed due to errors:\n\n" + "\n".join(error_slides))

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -154,9 +154,10 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                     # Remove .SVS from memory
                     del slide                    
                     print(f"\nLoaded slide: {time.time() - start_time:.2f} seconds")
+                    print(f"\nSize of WSI: {slide_array.shape}")
 
                     #Do edge detection here and reject unnecessary tiles BEFORE normalisation
-                    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img = slide_array, patch_size=patch_shape, step=step_size,
+                    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img=slide_array, patch_size=patch_shape, step=step_size,
                                                                                         outdir=cache_dir, save_tiles=False, cores=cores)
 
                     start_time = time.time()

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -155,8 +155,7 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                     print(f"\nSize of WSI: {slide_array.shape}")
 
                     #Do edge detection here and reject unnecessary tiles BEFORE normalisation
-                    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img=slide_array, patch_size=patch_shape, step=step_size,
-                                                                                        outdir=cache_dir, save_tiles=False, cores=cores)
+                    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img=slide_array, patch_size=patch_shape, step=step_size, cores=cores)
 
                     start_time = time.time()
                     # Pass raw slide_array for getting the initial concentrations, bg_reject_array for actual normalisation

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -18,6 +18,7 @@ import cv2
 import time
 from datetime import timedelta
 from pathlib import Path
+from random import shuffle
 import torch
 from typing import Optional
 from .helpers import stainNorm_Macenko
@@ -97,6 +98,7 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
     else:
         img_dir = list(wsi_dir.glob(f'**/*/{img_name}'))
 
+    shuffle(img_dir)
     for slide_url in tqdm(img_dir, "\nPreprocessing progress", leave=False, miniters=1, mininterval=0):
         if not only_feature_extraction:
             slide_name = Path(slide_url).stem

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -135,8 +135,9 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                         slide_array = load_slide(slide=slide, target_mpp=target_mpp, cores=cores)
                     except MPPExtractionError:
                         if del_slide:
-                            logging.error(f"Skipping slide and deleting due to missing MPP...")
-                            os.remove(str(slide_url))
+                            logging.error(f"MPP missing in slide metadata, deleting slide and continuing...")
+                            if os.path.exists(str(slide_url)):
+                                os.remove(str(slide_url))
                         else:
                             logging.error(f"Skipping slide due to missing MPP...")
                         continue
@@ -173,10 +174,11 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                     # Remove original slide jpg from memory
                     del slide_array
                     
-                    # Optionally removing the original slide from harddrive
+                    # Optionally remove the original slide from harddrive
                     if del_slide:
                         print(f"Deleting slide from local folder...")
-                        os.remove(str(slide_url))
+                        if os.path.exists(str(slide_url)):
+                            os.remove(str(slide_url))
 
                 print(f"\nExtracting CTransPath features from slide...")
                 start_time = time.time()
@@ -194,6 +196,7 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                 logging.info("Slide is already being processed. Skipping...")
             if del_slide:
                 print("Deleting slide from local folder...")
-                os.remove(str(slide_url))
+                if os.path.exists(str(slide_url)):
+                    os.remove(str(slide_url))
 
     logging.info(f"===== End-to-end processing time of {len(img_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} =====")

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -43,9 +43,8 @@ def lock_file(slide_path: Path):
 def save_image(image, path: Path):
     width, height = image.size
     if width > 65500 or height > 65500:
-        logging.warning(f"Image size ({width}x{height}) exceeds maximum size of 65500x65500, resizing {path.name} before saving...")
-        ratio = 65500 / max(width, height)
-        image = image.resize((int(width * ratio), int(height * ratio)))
+        logging.warning(f"Image size ({width}x{height}) exceeds maximum size of 65500x65500, {path.name} will not be cached...")
+        return
     image.save(path)
 
 def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Path,

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -102,7 +102,9 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
         
         feat_out_dir = output_file_dir/slide_name
 
-        if not (os.path.exists((f'{feat_out_dir}.h5'))):
+        if not (os.path.exists((f'{feat_out_dir}.h5'))) and not os.path.exists(f'{slide_url}.tmp'):
+            # TODO: delete .tmp file on keyboard interrupt / crash (catch exception in __main__.py (?))
+            Path(f'{slide_url}.tmp').touch()
             # Load WSI as one image
             if (only_feature_extraction and (slide_jpg := slide_url).exists()) \
                 or (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
@@ -183,9 +185,13 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                 print("0 tiles remain to extract features from after pre-processing {slide_name}, skipping...")
                 continue
             #########################
+            os.remove(f'{str(slide_url)}.tmp')
 
         else:
-            print(f"{slide_name}.h5 already exists. Skipping...")
+            if os.path.exists((f'{feat_out_dir}.h5')):
+                print(f"{slide_name}.h5 already exists. Skipping...")
+            else:
+                print(f"{slide_name} is already being processed. Skipping...")
             if del_slide:
                 print(f"Deleting slide {slide_name} from local folder...")
                 os.remove(str(slide_url))

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -140,6 +140,9 @@ def preprocess(output_dir: Path, wsi_dir: Path, model_path: Path, cache_dir: Pat
                         else:
                             logging.error(f"Skipping slide due to missing MPP...")
                         continue
+                    except openslide.lowlevel.OpenSlideError as e:
+                        logging.error(f"Failed loading slide, skipping... Error: {e}")
+                        continue
 
                     # Save raw .svs jpg
                     PIL.Image.fromarray(slide_array).save(f'{slide_cache_dir}/slide.jpg')


### PR DESCRIPTION
Changes:
- Improve efficiency when running multiple preprocessing tasks in parallel by creating temporary file indicating that a slide is already being processed
- Fix crash caused by OpenSlide "empty input file" error
- Improve readability of logged information during preprocessing, log more information about the used preprocessing configuration and print summary
- Move logfile from cache to features directory
- Add `cache` option to preprocessing config to allow opting out of saving intermediate images (Remedy for #5)
- Don't save intermediate images if larger than 65500 px (Fix for #5)
- Filter out already processed slides before starting processing loop (more accurate overall progress)
- Get rid of torch.meshgrid argument deprecation warning
- Remove dead code
- Increment version