### PR TITLE
Update to support scikit-learn 1.4.0

### DIFF
--- a/stamp/modeling/marugoto/transformer/helpers.py
+++ b/stamp/modeling/marugoto/transformer/helpers.py
@@ -104,7 +104,7 @@ def train_categorical_model_(
     with open(output_path/'info.json', 'w') as f:
         json.dump(info, f)
 
-    target_enc = OneHotEncoder(sparse=False).fit(categories.reshape(-1, 1))
+    target_enc = OneHotEncoder(sparse_output=False).fit(categories.reshape(-1, 1))
 
     add_features = []
     if cat_labels: add_features.append((_make_cat_enc(train_df, cat_labels), df[cat_labels].values))
@@ -138,7 +138,7 @@ def _make_cat_enc(df, cats) -> SKLearnEncoder:
         fitting_cats.append(non_na_samples)
     cat_samples = np.stack(fitting_cats, axis=1)
     cat_enc = make_pipeline(
-        OneHotEncoder(sparse=False, handle_unknown='ignore'),
+        OneHotEncoder(sparse_output=False, handle_unknown='ignore'),
         StandardScaler(),
     ).fit(cat_samples)
     return cat_enc
@@ -261,7 +261,7 @@ def categorical_crossval_(
     info['class distribution'] = {'overall': {
         k: int(v) for k, v in df[target_label].value_counts().items()}}
 
-    target_enc = OneHotEncoder(sparse=False).fit(categories.reshape(-1, 1))
+    target_enc = OneHotEncoder(sparse_output=False).fit(categories.reshape(-1, 1))
 
     if (fold_path := output_path/'folds.pt').exists():
         folds = torch.load(fold_path)


### PR DESCRIPTION
OneHotEncoder sparse argument has been renamed to sparse_output. It is already deprecated since version 1.2.

https://scikit-learn.org/1.3/modules/generated/sklearn.preprocessing.OneHotEncoder.html