### PR TITLE
Update cli.py

### DIFF
--- a/stamp/cli.py
+++ b/stamp/cli.py
@@ -181,7 +181,7 @@ def main() -> None:
     commands.add_parser("train", help="Train a Vision Transformer model")
     commands.add_parser("crossval", help="Train a Vision Transformer model with cross validation for modeling.n_splits folds")
     commands.add_parser("deploy", help="Deploy a trained Vision Transformer model")
-    commands.add_parser("statistics", help="Generate AUROCs and AUPRCs with 95%CI for a trained Vision Transformer model")
+    commands.add_parser("statistics", help="Generate AUROCs and AUPRCs with 95%%CI for a trained Vision Transformer model")
     commands.add_parser("config", help="Print the loaded configuration")
     commands.add_parser("heatmaps", help="Generate heatmaps for a trained model")
 


### PR DESCRIPTION
I think incorporating %% instructs Python to interpret the sequence as a literal % character, rather than introducing a string format specifier. Without proper escaping, executing the commands 'stamp' and 'stamp --help' trigger an error due to Python misinterpreting %C as an invalid format specifier, leading to:

ValueError: unsupported format character 'C' (0x43) at index 35