### PR TITLE
replace // by torch.div

### DIFF
--- a/stamp/heatmaps/__main__.py
+++ b/stamp/heatmaps/__main__.py
@@ -162,12 +162,12 @@ def main(
         preds, gradcam = gradcam_per_category(
             learn=learn, feats=feats, categories=categories
         )
-        gradcam_2d = vals_to_im(gradcam.permute(-1, -2), coords // stride).detach()
+        gradcam_2d = vals_to_im(gradcam.permute(-1, -2), div(coords, stride, rounding_mode='floor')).detach()
 
         scores = torch.softmax(
             learn.model(feats.unsqueeze(-2), torch.ones((len(feats)))), dim=1
         )
-        scores_2d = vals_to_im(scores, coords // stride).detach()
+        scores_2d = vals_to_im( div(coords, stride, rounding_mode='floor')).detach()
         fig, axs = plt.subplots(nrows=2, ncols=max(2, len(categories)), figsize=(12, 8))
 
         show_class_map(


### PR DESCRIPTION
Hi Omar,
I had an error in heatmaps, related to // being deprecated. I found that it should be replaced with torch.div, with rounding_method='floor' to keep previous behavior.
Victor