### PR TITLE
microns

### DIFF
--- a/stamp/cli.py
+++ b/stamp/cli.py
@@ -214,7 +214,8 @@ def run_cli(args: argparse.Namespace):
                  model_path=Path(c.model_path),
                  output_dir=Path(c.output_dir),
                  n_toptiles=int(c.n_toptiles),
-                 overview=c.overview)
+                 overview=c.overview),
+                 target_microns=int(cfg.preprocessing.microns)
         case _:
             raise ConfigurationError(f"Unknown command {args.command}")
 


### PR DESCRIPTION
This patch will avoid errors in heatmaps when microns is not the default 256.

I think the parser option --target_microns is not needed because options are read from config setup in cli, but it may be good to have if heatmap is ever called directly, not as a stamp option. I think this cannot be done as it is now.