### PR TITLE
Cast tile_target_size to tuple for resize

### DIFF
--- a/stamp/preprocessing/helpers/loading_slides.py
+++ b/stamp/preprocessing/helpers/loading_slides.py
@@ -35,7 +35,7 @@ def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224, cores: i
         for i in range(steps):  # row
             for j in range(steps):  # column
                 future = executor.submit(
-                    _load_tile, slide, (stride*(j, i)), stride, tile_target_size)
+                    _load_tile, slide, (stride*(j, i)), stride, tuple(tile_target_size))
                 future_coords[future] = (i, j)
 
         # write the loaded tiles into an image as soon as they are loaded


### PR DESCRIPTION
We supply `tile_target_size` as a numpy array here: https://github.com/KatherLab/STAMP/blob/845b39f1464ade8e77040797056cb8e02376d4d5/stamp/preprocessing/helpers/loading_slides.py#L37-L38

However, `PIL.Image.resize()` throws a `ValueError` when the size is supplied as a numpy array instead of a tuple (due to the comparison here: https://github.com/python-pillow/Pillow/blob/8c2a823e77735b4849fc921b0009220170cc82ea/src/PIL/Image.py#L2273). 

Solution is to convert it to a tuple for the `_load_tile` function (where the `target_size` parameter was already correctly type-annotated as tuple).
https://github.com/KatherLab/STAMP/blob/845b39f1464ade8e77040797056cb8e02376d4d5/stamp/preprocessing/helpers/loading_slides.py#L13-L15

Bug originally discovered by Narmin.
