### PR TITLE
Preprocessing: Add WSI prefetching

### DIFF
--- a/stamp/cli.py
+++ b/stamp/cli.py
@@ -173,7 +173,8 @@ def run_cli(args: argparse.Namespace):
                 only_feature_extraction=c.only_feature_extraction,
                 keep_dir_structure=c.keep_dir_structure if 'keep_dir_structure' in c else False,
                 device=c.device,
-                normalization_template=normalization_template_path
+                normalization_template=normalization_template_path,
+                preload_wsi=c.preload_wsi if 'preload_wsi' in c else False
             )
         case "train":
             require_configs(

--- a/stamp/config.yaml
+++ b/stamp/config.yaml
@@ -17,6 +17,7 @@ preprocessing:
   only_feature_extraction: false # Only perform feature extraction (intermediate images (background rejected, [normalized]) have to exist)
   cores: 8 # CPU cores to use
   device: cuda:0 # device to run feature extraction on (cpu, cuda, cuda:0, etc.)
+  preload_wsi: true # Preload the whole-slide image into temporary directory (helpful in case the slides are accessed over network)
 
 modeling:
   clini_table: # Path to clini_table file (.xlsx or .csv)

--- a/stamp/preprocessing/wsi_norm.py
+++ b/stamp/preprocessing/wsi_norm.py
@@ -41,6 +41,8 @@ def lock_file(slide_path: Path):
         Path(f"{slide_path}.lock").touch()
     except PermissionError:
         pass # No write permissions for wsi directory
+    except OSError:
+        pass # No write permissions for wsi directory
     try:
         yield
     finally:
@@ -51,6 +53,9 @@ def test_wsidir_write_permissions(wsi_dir: Path):
         testfile = wsi_dir/f"test_{str(os.getpid())}.tmp"
         Path(testfile).touch()
     except PermissionError:
+        logging.warning("No write permissions for wsi directory! If multiple stamp processes are running "
+                        "in parallel, the final summary may show an incorrect number of slides processed.")
+    except OSError:
         logging.warning("No write permissions for wsi directory! If multiple stamp processes are running "
                         "in parallel, the final summary may show an incorrect number of slides processed.")
     finally:


### PR DESCRIPTION
When the files containing compressed WSIs are located in network drives, the random accesses to extract tiles might be slow. The `preload_wsi` option first makes a copy of the WSI file in a temporary local directory and can massively speed up the tile extraction.

Please update your `config.yaml` file:

```
preprocessing:
  ...
  preload_wsi: true
```