### PR TITLE
Fix bug when only continuous labels are added

### DIFF
--- a/stamp/modeling/marugoto/transformer/base.py
+++ b/stamp/modeling/marugoto/transformer/base.py
@@ -159,7 +159,7 @@ def deploy(
         cat_enc = learn.dls.dataset._datasets[-2]._datasets[0].encode
         add_features.append((cat_enc, test_df[cat_labels].values))
     if cont_labels:
-        cont_enc = learn.dls.dataset._datasets[-2]._datasets[1].encode
+        cont_enc = learn.dls.dataset._datasets[-2]._datasets[-1].encode
         add_features.append((cont_enc, test_df[cont_labels].values))
 
     test_ds = make_dataset(


### PR DESCRIPTION
Fixes `IndexError: tuple index out of range` when continuous labels are added and no categorical labels.