### PR TITLE
Add documentation about the config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ stamp heatmaps   # generate heatmaps
 ```
 
 > [!NOTE]  
-> By default, STAMP will use the configuration file `config.yaml` in the current working directory (or, if that does not exist, it will use the [default STAMP configuration file](stamp/config.yaml) shipped with this package). If you want to use a different configuration file, use the `--config` command line option, i.e. `stamp --config some/other/file.yaml train`. You may also run `stamp init` to create a local `config.yaml` in the current working directory initialized to the default settings.
+> By default, STAMP will use the configuration file `config.yaml` in the current working directory (or, if that does not exist, it will use the [default STAMP configuration file](stamp/config.yaml) shipped with this package). If you want to use a different configuration file, use the `--config` command line option, i.e. `stamp --config some/other/file.yaml train`. Note that the `--config` option must be supplied before any of the subcommands. You may also run `stamp init` to create a local `config.yaml` in the current working directory initialized to the default settings.
 
 ## Reference
 

--- a/stamp/cli.py
+++ b/stamp/cli.py
@@ -266,7 +266,7 @@ def run_cli(args: argparse.Namespace):
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="stamp", description="STAMP: Solid Tumor Associative Modeling in Pathology")
-    parser.add_argument("--config", "-c", type=Path, default=None, help=f"Path to config file (if unspecified, defaults to {DEFAULT_CONFIG_FILE.absolute()} or the default STAMP config file shipped with the package if {DEFAULT_CONFIG_FILE.absolute()} does not exist)")
+    parser.add_argument("--config", "-c", type=Path, default=None, help=f"Path to config file. Note that the --config option must be supplied before any of the subcommands. If unspecified, defaults to {DEFAULT_CONFIG_FILE.absolute()} or the default STAMP config file shipped with the package if {DEFAULT_CONFIG_FILE.absolute()} does not exist.")
 
     commands = parser.add_subparsers(dest="command")
     commands.add_parser("init", help="Create a new STAMP configuration file at the path specified by --config")


### PR DESCRIPTION
There was some confusion about the fact that `stamp train --config {file}` doesn't work (the config option must be specified before the subcommand, e.g. `stamp --config {file} train`). This PR adds a note to make this more explicit. 