### PR TITLE
Fix buffer registration

### DIFF
--- a/src/stamp/modeling/alibi.py
+++ b/src/stamp/modeling/alibi.py
@@ -8,8 +8,8 @@ class _RunningMeanScaler(nn.Module):
 
     def __init__(self, dtype=torch.float32) -> None:
         super().__init__()
-        self.running_mean = nn.Buffer(torch.ones(1, dtype=dtype))
-        self.items_so_far = nn.Buffer(torch.ones(1, dtype=dtype))
+        self.register_buffer("running_mean", torch.ones(1, dtype=dtype))
+        self.register_buffer("items_so_far", torch.ones(1, dtype=dtype))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.training:


### PR DESCRIPTION
## Summary
- register running stats as model buffers for ALiBi

## Testing
- `ruff check src/stamp/modeling/alibi.py`
- `pyright src/stamp/modeling/alibi.py` *(fails: Import "torch" could not be resolved)*