### PR TITLE
Added .h5 file extension error message in regards to Issue #95

### DIFF
--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -469,26 +469,23 @@ def slide_to_patient_from_slide_table_(
     filename_label: PandasLabel,
 ) -> dict[FeaturePath, PatientId]:
     """Creates a slide-to-patient mapping from a slide table."""
-    print("Entering slide_to_patient_from_slide_table_")
+    print("Entering slide_to_patient_from_slide_table_", flush=True)
     slide_df = read_table(
         slide_table_path,
         usecols=[patient_label, filename_label],
         dtype=str,
     )
-    # Verify the slide table contains a feature path with .h5 extension
-    # Re: Issue #95
+    # Verify the slide table contains a feature path with .h5 extension by
+    # checking the filename_label.
     any_h5 = False
-    # for path in filename_label:
-    #     if path.endswith(".h5"):
-    #         any_h5 = True
-    # need to check the slide DataFrame that's already loaded in the function
     for x in slide_df[filename_label]:
         if x.endswith(".h5"):
             any_h5 = True
     if any_h5 is False:
-        print("Hit the No .h5 error")
+        print("Hit the No .h5 error", flush=True)
         raise ValueError(
-            "No .h5 extensions found in the slide table's feature path"
+            "No .h5 extensions found in the slide table's filename_label "
+            "column"
         )
 
     slide_to_patient: Mapping[FeaturePath, PatientId] = {

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -474,7 +474,22 @@ def slide_to_patient_from_slide_table_(
         usecols=[patient_label, filename_label],
         dtype=str,
     )
-
+    # Verify the slide table contains a feature path with .h5 extension
+    # Re: Issue #95
+    any_h5 = False
+    # for path in filename_label:
+    #     if path.endswith(".h5"):
+    #         any_h5 = True
+    # need to check the sldie DataFrame that's already loaded in the function
+    for x in slide_df[filename_label]:
+        if x.endswith(".h5"):
+            any_h5 = True
+    if any_h5 is False:
+        print("Hit the No .h5 error")
+        raise ValueError(
+            "No .h5 extensions found in the slide table's feature path"
+        )
+        
     slide_to_patient: Mapping[FeaturePath, PatientId] = {
         FeaturePath(feature_dir / cast(str, k)): PatientId(cast(str, patient))
         for k, patient in slide_df.set_index(filename_label, verify_integrity=True)[

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -469,6 +469,7 @@ def slide_to_patient_from_slide_table_(
     filename_label: PandasLabel,
 ) -> dict[FeaturePath, PatientId]:
     """Creates a slide-to-patient mapping from a slide table."""
+    print("Entering slide_to_patient_from_slide_table_")
     slide_df = read_table(
         slide_table_path,
         usecols=[patient_label, filename_label],

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -468,7 +468,12 @@ def slide_to_patient_from_slide_table_(
     patient_label: PandasLabel,
     filename_label: PandasLabel,
 ) -> dict[FeaturePath, PatientId]:
-    """Creates a slide-to-patient mapping from a slide table."""
+    """
+    Creates a slide-to-patient mapping from a slide table.
+    Side effects:
+        Checks to see if least one file in the slide table's
+        filename_label column has an .h5 extension.
+    """
     print("Entering slide_to_patient_from_slide_table_", flush=True)
     slide_df = read_table(
         slide_table_path,

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -480,7 +480,7 @@ def slide_to_patient_from_slide_table_(
     # for path in filename_label:
     #     if path.endswith(".h5"):
     #         any_h5 = True
-    # need to check the sldie DataFrame that's already loaded in the function
+    # need to check the slide DataFrame that's already loaded in the function
     for x in slide_df[filename_label]:
         if x.endswith(".h5"):
             any_h5 = True
@@ -489,7 +489,7 @@ def slide_to_patient_from_slide_table_(
         raise ValueError(
             "No .h5 extensions found in the slide table's feature path"
         )
-        
+
     slide_to_patient: Mapping[FeaturePath, PatientId] = {
         FeaturePath(feature_dir / cast(str, k)): PatientId(cast(str, patient))
         for k, patient in slide_df.set_index(filename_label, verify_integrity=True)[

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -474,7 +474,6 @@ def slide_to_patient_from_slide_table_(
         Checks to see if least one file in the slide table's
         filename_label column has an .h5 extension.
     """
-    print("Entering slide_to_patient_from_slide_table_", flush=True)
     slide_df = read_table(
         slide_table_path,
         usecols=[patient_label, filename_label],
@@ -487,7 +486,6 @@ def slide_to_patient_from_slide_table_(
         if x.endswith(".h5"):
             any_h5 = True
     if any_h5 is False:
-        print("Hit the No .h5 error", flush=True)
         raise ValueError(
             "No .h5 extensions found in the slide table's filename_label "
             "column"

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -471,8 +471,8 @@ def slide_to_patient_from_slide_table_(
     """
     Creates a slide-to-patient mapping from a slide table.
     Side effects:
-        Checks to see if least one file in the slide table's
-        filename_label column has an .h5 extension.
+        Verifies that all files in the slide tables filename_label
+        column has an .h5 extension.
     """
     slide_df = read_table(
         slide_table_path,
@@ -481,15 +481,13 @@ def slide_to_patient_from_slide_table_(
     )
     # Verify the slide table contains a feature path with .h5 extension by
     # checking the filename_label.
-    any_h5 = False
     for x in slide_df[filename_label]:
-        if x.endswith(".h5"):
-            any_h5 = True
-    if any_h5 is False:
-        raise ValueError(
-            "No .h5 extensions found in the slide table's filename_label "
-            "column"
-        )
+        if not str(x).endswith(".h5"):
+            raise ValueError(
+                "One or more files are missing the .h5 extension in the "
+                "filename_label column. The first file missing the .h5 "
+                "extension is: " + str(x) + "."
+            )
 
     slide_to_patient: Mapping[FeaturePath, PatientId] = {
         FeaturePath(feature_dir / cast(str, k)): PatientId(cast(str, patient))

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -309,17 +309,13 @@ def make_patient_level_feature_file(
 def create_good_and_bad_slide__tables(
         *,
         tmp_path: Path
-        ) :
+        ) -> tuple[Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
     contain .h5 extensions and bad slide tables do not.
     """
     # Create bad slide table (no .h5 extension)
-    # bad_slide_df = pd.DataFrame({
-    #     "patient": ["pat_bad1", "pat_bad2", "pat_bad3"],
-    #     "slide_path": ["slide1.jpg", "slide2.png", "slide3.tiff"]
-    # })
 
     bad_slide_df = pd.DataFrame({
         "PATIENT": ["pat_bad1", "pat_bad2", "pat_bad3"],
@@ -340,22 +336,27 @@ def create_good_and_bad_slide__tables(
 
     return good_slide_path, bad_slide_path
 
-# def create_random_slide_tables(
-#         *,
-#         dir: Path,
-#         tmp_path: Path, 
-#         slide_path_to_patient: Mapping[Path, PatientId] = {},
+def create_random_slide_tables(
+        *,
+        dir: Path,
+        tmp_path: Path,
+        ) -> tuple[Path, Path]:
+    """
+    Randomly creates two slide tables for testing
+    slide_to_patient_from_slide_table_ in data.py. Good slide tables
+    contain .h5 extensions and bad slide tables do not.
+    """
+    bad_extensions =[ ".jpg", ".pdf", ".png", "gir"]
 
-#         ):
-#      """
-#     Randomly creates two slide tables for testing
-#     slide_to_patient_from_slide_table_ in data.py. Good slide tables
-#     contain .h5 extensions and bad slide tables do not.
-#     """
-#     for x in range(10)
+    words = []
+    for x in range(10):
+        word = random_string(random.randint(5, b=12))
+        words.append(word)
 
-#     bad_slide_df = pd.DataFrame (
-#         slide_path_to_patient.items(),
-#         columns=["slide_path", "patient"],
-#     )
+    
+    bad_slide_df = pd.DataFrame (
+        slide_path_to_patient.items(),
+        columns=["slide_path", "patient"],
+    )
 
+    return good_random_slide_path, bad_random_slide_path

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -306,57 +306,78 @@ def make_patient_level_feature_file(
     file.seek(0)
     return file
 
-def create_good_and_bad_slide__tables(
-        *,
-        tmp_path: Path
-        ) -> tuple[Path, Path]:
+def create_good_and_bad_slide__tables(*, tmp_path: Path) -> tuple[Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
     contain .h5 extensions and bad slide tables do not.
     """
-    # Create bad slide table (no .h5 extension)
-
-    bad_slide_df = pd.DataFrame({
-        "PATIENT": ["pat_bad1", "pat_bad2", "pat_bad3"],
-        "FILENAME": ["slide1.jpg", "slide2.png", "slide3.tiff"]
-    })
-    
-    bad_slide_path = tmp_path / "bad_slide.csv"
-    bad_slide_df.to_csv(bad_slide_path, index=False)
-
     # Create good slide table (with .h5 extension)
-    good_slide_df = pd.DataFrame({
-        "PATIENT": ["pat1", "pat2", "pat3"], 
-        "FILENAME": ["slide1.h5", "slide2.h5", "slide3.h5"]
-    })
+    good_slide_df = pd.DataFrame(
+        {
+            "PATIENT": ["pat1", "pat2", "pat3"],
+            "FILENAME": ["slide1.h5", "slide2.h5", "slide3.h5"],
+        }
+    )
 
     good_slide_path = tmp_path / "good_slide.csv"
     good_slide_df.to_csv(good_slide_path, index=False)
+    # Create bad slide table (no .h5 extension)
+    bad_slide_df = pd.DataFrame(
+        {
+            "PATIENT": ["pat_bad1", "pat_bad2", "pat_bad3"],
+            "FILENAME": ["slide1.jpg", "slide2.png", "slide3.tiff"],
+        }
+    )
+
+    bad_slide_path = tmp_path / "bad_slide.csv"
+    bad_slide_df.to_csv(bad_slide_path, index=False)
 
     return good_slide_path, bad_slide_path
 
 def create_random_slide_tables(
         *,
-        dir: Path,
-        tmp_path: Path,
-        ) -> tuple[Path, Path]:
+        n_patients: int,
+        tmp_path: Path) -> tuple[Path, Path]:
     """
     Randomly creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
     contain .h5 extensions and bad slide tables do not.
     """
-    bad_extensions =[ ".jpg", ".pdf", ".png", "gir"]
+    bad_extensions = [
+        ".jpg",
+        ".pdf",
+        ".png",
+        ".bmp",
+        ".gif",
+        ".jpeg",
+        ".svg",
+        ".webp",
+        ".tff",
+        ".cur",
+    ]
 
-    words = []
-    for x in range(10):
-        word = random_string(random.randint(5, b=12))
-        words.append(word)
+    names = []
+    for i in range(n_patients):
+        names.append("pat" + str(i))
 
-    
-    bad_slide_df = pd.DataFrame (
-        slide_path_to_patient.items(),
-        columns=["slide_path", "patient"],
-    )
+    good_files = []
+    bad_files = []
+    # words = []
+    for x in range(n_patients):
+        word = random_string(random.randint(5, 12))
+        # words.append(word)
+        good_files.append(word + ".h5")
+        bad_files.append(word + random.choice(bad_extensions))
 
-    return good_random_slide_path, bad_random_slide_path
+    good_slide_df = pd.DataFrame({"PATIENT": names, "FILENAME": good_files})
+
+    good_slide_path = tmp_path / "good_random_slide.csv"
+    good_slide_df.to_csv(good_slide_path, index=False)
+
+    bad_slide_df = pd.DataFrame({"PATIENT": names, "FILENAME": bad_files})
+
+    bad_slide_path = tmp_path / "bad_random_slide.csv"
+    bad_slide_df.to_csv(bad_slide_path, index=False)
+
+    return good_slide_path, bad_slide_path

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -308,7 +308,7 @@ def make_patient_level_feature_file(
 
 
 def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[
-        Path, Path, Path, Path]:
+        Path, Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -305,3 +305,52 @@ def make_patient_level_feature_file(
         h5.attrs["feat_type"] = "patient"
     file.seek(0)
     return file
+
+def create_good_and_bad_slide__tables(
+        *,
+        tmp_path: Path
+        ) :
+    """
+    Manually creates two slide tables for testing
+    slide_to_patient_from_slide_table_ in data.py. Good slide tables
+    contain .h5 extensions and bad slide tables do not.
+    """
+    # Create bad slide table (no .h5 extension)
+    bad_slide_df = pd.DataFrame({
+        "patient": ["pat_bad1", "pat_bad2", "pat_bad3"],
+        "slide_path": ["slide1.jpg", "slide2.png", "slide3.tiff"]
+    })
+    
+    bad_slide_path = tmp_path / "bad_slide.csv"
+    bad_slide_df.to_csv(bad_slide_path, index=False)
+
+    # Create good slide table (with .h5 extension)
+    good_slide_df = pd.DataFrame({
+        "patient": ["pat1", "pat2", "pat3"], 
+        "slide_path": ["slide1.h5", "slide2.h5", "slide3.h5"]
+    })
+
+    good_slide_path = tmp_path / "good_slide.csv"
+    good_slide_df.to_csv(good_slide_path, index=False)
+
+    return good_slide_path, bad_slide_path
+
+def create_random_slide_tables(
+        *,
+        dir: Path,
+        tmp_path: Path, 
+        slide_path_to_patient: Mapping[Path, PatientId] = {},
+
+        ):
+     """
+    Randomly creates two slide tables for testing
+    slide_to_patient_from_slide_table_ in data.py. Good slide tables
+    contain .h5 extensions and bad slide tables do not.
+    """
+    for x in range(10)
+
+    bad_slide_df = pd.DataFrame (
+        slide_path_to_patient.items(),
+        columns=["slide_path", "patient"],
+    )
+

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -307,8 +307,7 @@ def make_patient_level_feature_file(
     return file
 
 
-def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[
-        Path, Path, Path]:
+def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[Path, Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
@@ -340,8 +339,13 @@ def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[
     one_bad_slide_df = pd.DataFrame(
         {
             "PATIENT": ["pat1", "pat2", "badpat3", "pat4", "pat5"],
-            "FILENAME": ["slide1.h5", "slide2.h5", "slide3.jpg", "slide4.h5",
-                         "slide5.h5",],
+            "FILENAME": [
+                "slide1.h5",
+                "slide2.h5",
+                "slide3.jpg",
+                "slide4.h5",
+                "slide5.h5",
+            ],
         }
     )
     one_bad_slide_df.to_csv(one_bad_slide_path, index=False)
@@ -353,10 +357,7 @@ def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[
     )
 
 
-def create_random_slide_tables(
-        *,
-        n_patients: int,
-        tmp_path: Path) -> tuple[Path, Path]:
+def create_random_slide_tables(*, n_patients: int, tmp_path: Path) -> tuple[Path, Path]:
     """
     Randomly creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -306,12 +306,14 @@ def make_patient_level_feature_file(
     file.seek(0)
     return file
 
+
 def create_good_and_bad_slide__tables(*, tmp_path: Path) -> tuple[Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
     contain .h5 extensions and bad slide tables do not.
     """
+
     # Create good slide table (with .h5 extension)
     good_slide_df = pd.DataFrame(
         {
@@ -319,9 +321,9 @@ def create_good_and_bad_slide__tables(*, tmp_path: Path) -> tuple[Path, Path]:
             "FILENAME": ["slide1.h5", "slide2.h5", "slide3.h5"],
         }
     )
-
     good_slide_path = tmp_path / "good_slide.csv"
     good_slide_df.to_csv(good_slide_path, index=False)
+
     # Create bad slide table (no .h5 extension)
     bad_slide_df = pd.DataFrame(
         {
@@ -329,11 +331,11 @@ def create_good_and_bad_slide__tables(*, tmp_path: Path) -> tuple[Path, Path]:
             "FILENAME": ["slide1.jpg", "slide2.png", "slide3.tiff"],
         }
     )
-
     bad_slide_path = tmp_path / "bad_slide.csv"
     bad_slide_df.to_csv(bad_slide_path, index=False)
 
     return good_slide_path, bad_slide_path
+
 
 def create_random_slide_tables(
         *,
@@ -363,20 +365,16 @@ def create_random_slide_tables(
 
     good_files = []
     bad_files = []
-    # words = []
-    for x in range(n_patients):
+    for _ in range(n_patients):
         word = random_string(random.randint(5, 12))
-        # words.append(word)
         good_files.append(word + ".h5")
         bad_files.append(word + random.choice(bad_extensions))
 
     good_slide_df = pd.DataFrame({"PATIENT": names, "FILENAME": good_files})
-
     good_slide_path = tmp_path / "good_random_slide.csv"
     good_slide_df.to_csv(good_slide_path, index=False)
 
     bad_slide_df = pd.DataFrame({"PATIENT": names, "FILENAME": bad_files})
-
     bad_slide_path = tmp_path / "bad_random_slide.csv"
     bad_slide_df.to_csv(bad_slide_path, index=False)
 

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -316,9 +316,14 @@ def create_good_and_bad_slide__tables(
     contain .h5 extensions and bad slide tables do not.
     """
     # Create bad slide table (no .h5 extension)
+    # bad_slide_df = pd.DataFrame({
+    #     "patient": ["pat_bad1", "pat_bad2", "pat_bad3"],
+    #     "slide_path": ["slide1.jpg", "slide2.png", "slide3.tiff"]
+    # })
+
     bad_slide_df = pd.DataFrame({
-        "patient": ["pat_bad1", "pat_bad2", "pat_bad3"],
-        "slide_path": ["slide1.jpg", "slide2.png", "slide3.tiff"]
+        "PATIENT": ["pat_bad1", "pat_bad2", "pat_bad3"],
+        "FILENAME": ["slide1.jpg", "slide2.png", "slide3.tiff"]
     })
     
     bad_slide_path = tmp_path / "bad_slide.csv"
@@ -326,8 +331,8 @@ def create_good_and_bad_slide__tables(
 
     # Create good slide table (with .h5 extension)
     good_slide_df = pd.DataFrame({
-        "patient": ["pat1", "pat2", "pat3"], 
-        "slide_path": ["slide1.h5", "slide2.h5", "slide3.h5"]
+        "PATIENT": ["pat1", "pat2", "pat3"], 
+        "FILENAME": ["slide1.h5", "slide2.h5", "slide3.h5"]
     })
 
     good_slide_path = tmp_path / "good_slide.csv"
@@ -335,22 +340,22 @@ def create_good_and_bad_slide__tables(
 
     return good_slide_path, bad_slide_path
 
-def create_random_slide_tables(
-        *,
-        dir: Path,
-        tmp_path: Path, 
-        slide_path_to_patient: Mapping[Path, PatientId] = {},
+# def create_random_slide_tables(
+#         *,
+#         dir: Path,
+#         tmp_path: Path, 
+#         slide_path_to_patient: Mapping[Path, PatientId] = {},
 
-        ):
-     """
-    Randomly creates two slide tables for testing
-    slide_to_patient_from_slide_table_ in data.py. Good slide tables
-    contain .h5 extensions and bad slide tables do not.
-    """
-    for x in range(10)
+#         ):
+#      """
+#     Randomly creates two slide tables for testing
+#     slide_to_patient_from_slide_table_ in data.py. Good slide tables
+#     contain .h5 extensions and bad slide tables do not.
+#     """
+#     for x in range(10)
 
-    bad_slide_df = pd.DataFrame (
-        slide_path_to_patient.items(),
-        columns=["slide_path", "patient"],
-    )
+#     bad_slide_df = pd.DataFrame (
+#         slide_path_to_patient.items(),
+#         columns=["slide_path", "patient"],
+#     )
 

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -307,7 +307,8 @@ def make_patient_level_feature_file(
     return file
 
 
-def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[Path, Path]:
+def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[
+        Path, Path, Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables
@@ -325,16 +326,31 @@ def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[Path, Path]:
     good_slide_df.to_csv(good_slide_path, index=False)
 
     # Create bad slide table (no .h5 extension)
-    bad_slide_df = pd.DataFrame(
+    all_bad_slide_df = pd.DataFrame(
         {
             "PATIENT": ["pat_bad1", "pat_bad2", "pat_bad3"],
             "FILENAME": ["slide1.jpg", "slide2.png", "slide3.tiff"],
         }
     )
-    bad_slide_path = tmp_path / "bad_slide.csv"
-    bad_slide_df.to_csv(bad_slide_path, index=False)
+    all_bad_slide_path = tmp_path / "bad_slide.csv"
+    all_bad_slide_df.to_csv(all_bad_slide_path, index=False)
 
-    return good_slide_path, bad_slide_path
+    # Create slide table with one file without .h5 extension
+    one_bad_slide_path = tmp_path / "one_bad_slide.csv"
+    one_bad_slide_df = pd.DataFrame(
+        {
+            "PATIENT": ["pat1", "pat2", "badpat3", "pat4", "pat5"],
+            "FILENAME": ["slide1.h5", "slide2.h5", "slide3.jpg", "slide4.h5",
+                         "slide5.h5",],
+        }
+    )
+    one_bad_slide_df.to_csv(one_bad_slide_path, index=False)
+
+    return (
+        good_slide_path,
+        all_bad_slide_path,
+        one_bad_slide_path,
+    )
 
 
 def create_random_slide_tables(

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -307,7 +307,7 @@ def make_patient_level_feature_file(
     return file
 
 
-def create_good_and_bad_slide__tables(*, tmp_path: Path) -> tuple[Path, Path]:
+def create_good_and_bad_slide_tables(*, tmp_path: Path) -> tuple[Path, Path]:
     """
     Manually creates two slide tables for testing
     slide_to_patient_from_slide_table_ in data.py. Good slide tables

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -9,7 +9,7 @@ from random_data import (
     create_random_patient_level_feature_file,
     make_feature_file,
     make_old_feature_file,
-    create_good_and_bad_slide__tables,
+    create_good_and_bad_slide_tables,
     create_random_slide_tables
 )
 from torch.utils.data import DataLoader
@@ -217,7 +217,7 @@ def test_get_coords_historic_format() -> None:
         assert coords_info.mpp == SlideMPP(256.0 / 224)
 
 
-def test_slide_table_h5_validation(tmp_path: Path):
+def test_slide_table_h5_validation(tmp_path: Path) -> None:
     """
     Tests that an error is properly raised in
     slide_to_patient_from_slide_table_() when none of items in the
@@ -227,9 +227,9 @@ def test_slide_table_h5_validation(tmp_path: Path):
     """
     feature_dir = tmp_path
 
-    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(
+    good_slide_path, bad_slide_path = create_good_and_bad_slide_tables(
         tmp_path=tmp_path)
-    
+
     # Test with .h5 extensions in filename_label column (should be no error
     # regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
@@ -249,7 +249,7 @@ def test_slide_table_h5_validation(tmp_path: Path):
             filename_label="FILENAME")
 
 
-def test_slide_table_h5_validation_random(tmp_path: Path, ):
+def test_slide_table_h5_validation_random(tmp_path: Path, ) -> None:
     """
     Tests that an error is properly raised in
     slide_to_patient_from_slide_table_() when none of items in the

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -9,6 +9,7 @@ from random_data import (
     create_random_patient_level_feature_file,
     make_feature_file,
     make_old_feature_file,
+    create_good_and_bad_slide__tables,
 )
 from torch.utils.data import DataLoader
 
@@ -19,6 +20,7 @@ from stamp.modeling.data import (
     PatientFeatureDataset,
     filter_complete_patient_data_,
     get_coords,
+    slide_to_patient_from_slide_table_,
 )
 from stamp.types import (
     BagSize,
@@ -213,52 +215,65 @@ def test_get_coords_historic_format() -> None:
         assert coords_info.tile_size_px == TilePixels(224)
         assert coords_info.mpp == SlideMPP(256.0 / 224)
 
-
-def test_slide_table_h5_validation(tmp_path: Path):
-    """
+def test_slide_table_h5_validation (tmp_path: Path):
+ """
     Test that an error is raised in 
     slide_to_patient_from_slide_table_() when no .h5 files are in the slide
     table.
     """
+    feature_dir = tmp_path
 
-    slide_path = dir / "slide.csv"
+    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(tmp_path=tmp_path,)
+    
+    assert slide_to_patient_from_slide_table_(slide_table_path=good_slide_path, feature_dir=feature_dir)
+
+# def test_slide_table_h5_validation_random(tmp_path: Path, ):
+#     """
+#     Test that an error is raised in 
+#     slide_to_patient_from_slide_table_() when no .h5 files are in the slide
+#     table.
+#     """
+
+#     slide_path = dir / "slide.csv"
 
   
 
-    # Create temp paths
-    (tmp_path / "test_data").mkdir()
+#     # Create temp paths
+#     (tmp_path / "test_data").mkdir()
 
-    # Create bad slide table
-    bad_slide_table = "bad_slide"
-    bad_feature_dir = ""
-    bad_patient_label = 1
-    bad_filename_label = 1
-    # Create a good slide table
+#     # Create bad slide table
+#     bad_slide_table = "bad_slide"
+#     bad_feature_dir = ""
+#     bad_patient_label = 1
+#     bad_filename_label = 1
 
-    clini_pathj = slide_path, feat_dir, categories = create_random_dataset(
-        
-    )
     
-    good_slide_table= 2
-    good_feature_dir = 2
-    good_patient_label = 2
-    good_filename_label = 2
+#     # Create a good slide table
 
-    # This should raise an error   
-    slide_df = pd.DataFrame(
-        slide_path_to_patient.items()
-    )
-    assert
-    slide_to_patient_from_slide_table_(
-    slide_table_path=bad_slide_table,
-            feature_dir=bad_feature_dir,
-            patient_label=bad_patient_label,
-            filename_label=bad_filename_label,
-) 
-    # This should not raise an error
-    slide_to_patient_from_slide_table_(
-    slide_table_path=good_slide_table,
-            feature_dir=good_feature_dir,
-            patient_label=good_patient_label,
-            filename_label=good_filename_label,
-) 
+#     clini_pathj = slide_path, feat_dir, categories = create_random_dataset(
+        
+#     )
+    
+#     good_slide_table= 2
+#     good_feature_dir = 2
+#     good_patient_label = 2
+#     good_filename_label = 2
+
+#     # This should raise an error   
+#     slide_df = pd.DataFrame(
+#         slide_path_to_patient.items()
+#     )
+#     assert
+#     slide_to_patient_from_slide_table_(
+#     slide_table_path=bad_slide_table,
+#             feature_dir=bad_feature_dir,
+#             patient_label=bad_patient_label,
+#             filename_label=bad_filename_label,
+# ) 
+#     # This should not raise an error
+#     slide_to_patient_from_slide_table_(
+#     slide_table_path=good_slide_table,
+#             feature_dir=good_feature_dir,
+#             patient_label=good_patient_label,
+#             filename_label=good_filename_label,
+# ) 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -212,3 +212,53 @@ def test_get_coords_historic_format() -> None:
         assert coords_info.tile_size_um == Microns(256.0)
         assert coords_info.tile_size_px == TilePixels(224)
         assert coords_info.mpp == SlideMPP(256.0 / 224)
+
+
+def test_slide_table_h5_validation(tmp_path: Path):
+    """
+    Test that an error is raised in 
+    slide_to_patient_from_slide_table_() when no .h5 files are in the slide
+    table.
+    """
+
+    slide_path = dir / "slide.csv"
+
+  
+
+    # Create temp paths
+    (tmp_path / "test_data").mkdir()
+
+    # Create bad slide table
+    bad_slide_table = "bad_slide"
+    bad_feature_dir = ""
+    bad_patient_label = 1
+    bad_filename_label = 1
+    # Create a good slide table
+
+    clini_pathj = slide_path, feat_dir, categories = create_random_dataset(
+        
+    )
+    
+    good_slide_table= 2
+    good_feature_dir = 2
+    good_patient_label = 2
+    good_filename_label = 2
+
+    # This should raise an error   
+    slide_df = pd.DataFrame(
+        slide_path_to_patient.items()
+    )
+    assert
+    slide_to_patient_from_slide_table_(
+    slide_table_path=bad_slide_table,
+            feature_dir=bad_feature_dir,
+            patient_label=bad_patient_label,
+            filename_label=bad_filename_label,
+) 
+    # This should not raise an error
+    slide_to_patient_from_slide_table_(
+    slide_table_path=good_slide_table,
+            feature_dir=good_feature_dir,
+            patient_label=good_patient_label,
+            filename_label=good_filename_label,
+) 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -264,7 +264,6 @@ def test_slide_table_h5_validation_random(tmp_path: Path, ):
     good_slide_path, bad_slide_path = create_random_slide_tables(
         n_patients=10,
         tmp_path=tmp_path)
-
     # Test with .h5 extensions in filename_label column (should be no error
     # regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
@@ -273,6 +272,7 @@ def test_slide_table_h5_validation_random(tmp_path: Path, ):
             patient_label="PATIENT",
             filename_label="FILENAME")
     assert isinstance(result, dict)
+
     # Test without .h5 extensions in filename_label column
     with pytest.raises(ValueError,
                        match="No .h5 extensions found in the slide table's "

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -215,17 +215,33 @@ def test_get_coords_historic_format() -> None:
         assert coords_info.tile_size_px == TilePixels(224)
         assert coords_info.mpp == SlideMPP(256.0 / 224)
 
+
 def test_slide_table_h5_validation (tmp_path: Path):
- """
+    """
     Test that an error is raised in 
     slide_to_patient_from_slide_table_() when no .h5 files are in the slide
     table.
     """
     feature_dir = tmp_path
 
-    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(tmp_path=tmp_path,)
-    
-    assert slide_to_patient_from_slide_table_(slide_table_path=good_slide_path, feature_dir=feature_dir)
+    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(tmp_path=tmp_path)
+    # remember that PandasLabel is just a string
+
+    # Test Good Slide Path (should be no error or error that doesn't contain the error I made)
+    # assert slide_to_patient_from_slide_table_(slide_table_path=good_slide_path, feature_dir=feature_dir, patient_label="PATIENT", filename_label="FILENAME")
+    with pytest.raises(ValueError, match="No .h5 extensions found in the slide table's feature path"):
+        slide_to_patient_from_slide_table_(
+            slide_table_path=good_slide_path,
+            feature_dir=feature_dir,
+            patient_label="PATIENT",
+            filename_label="FILENAME")
+    # Test Bad Slide Path
+    with pytest.raises(ValueError, match="No .h5 extensions found in the slide table's feature path"):
+        slide_to_patient_from_slide_table_(
+            slide_table_path=bad_slide_path,
+            feature_dir=feature_dir,
+            patient_label="PATIENT",
+            filename_label="FILENAME")
 
 # def test_slide_table_h5_validation_random(tmp_path: Path, ):
 #     """
@@ -236,7 +252,7 @@ def test_slide_table_h5_validation (tmp_path: Path):
 
 #     slide_path = dir / "slide.csv"
 
-  
+
 
 #     # Create temp paths
 #     (tmp_path / "test_data").mkdir()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,6 +10,7 @@ from random_data import (
     make_feature_file,
     make_old_feature_file,
     create_good_and_bad_slide__tables,
+    create_random_dataset
 )
 from torch.utils.data import DataLoader
 
@@ -216,27 +217,32 @@ def test_get_coords_historic_format() -> None:
         assert coords_info.mpp == SlideMPP(256.0 / 224)
 
 
-def test_slide_table_h5_validation (tmp_path: Path):
+def test_slide_table_h5_validation(tmp_path: Path):
     """
-    Test that an error is raised in 
-    slide_to_patient_from_slide_table_() when no .h5 files are in the slide
-    table.
+    Tests that an error is properly raised in
+    slide_to_patient_from_slide_table_( when none of items in the
+    filename_labels column of a slide table have an .h5 extension and
+    verifies that the error isn't raised when
+    
     """
     feature_dir = tmp_path
 
-    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(tmp_path=tmp_path)
+    good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(
+        tmp_path=tmp_path)
     # remember that PandasLabel is just a string
 
-    # Test Good Slide Path (should be no error or error that doesn't contain the error I made)
-    # assert slide_to_patient_from_slide_table_(slide_table_path=good_slide_path, feature_dir=feature_dir, patient_label="PATIENT", filename_label="FILENAME")
-    with pytest.raises(ValueError, match="No .h5 extensions found in the slide table's feature path"):
-        slide_to_patient_from_slide_table_(
+    # Test with .h5 extensions in filename_label column (should be no error
+    # regarding no .h5 extensions)
+    result = slide_to_patient_from_slide_table_(
             slide_table_path=good_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
             filename_label="FILENAME")
-    # Test Bad Slide Path
-    with pytest.raises(ValueError, match="No .h5 extensions found in the slide table's feature path"):
+    assert isinstance(result, dict)
+    # Test without .h5 extensions in filename_label column
+    with pytest.raises(ValueError,
+                       match="No .h5 extensions found in the slide table's "
+                       "filename_label column"):
         slide_to_patient_from_slide_table_(
             slide_table_path=bad_slide_path,
             feature_dir=feature_dir,
@@ -250,46 +256,15 @@ def test_slide_table_h5_validation (tmp_path: Path):
 #     table.
 #     """
 
-#     slide_path = dir / "slide.csv"
-
-
-
-#     # Create temp paths
-#     (tmp_path / "test_data").mkdir()
-
-#     # Create bad slide table
-#     bad_slide_table = "bad_slide"
-#     bad_feature_dir = ""
-#     bad_patient_label = 1
-#     bad_filename_label = 1
-
-    
-#     # Create a good slide table
-
-#     clini_pathj = slide_path, feat_dir, categories = create_random_dataset(
-        
-#     )
-    
-#     good_slide_table= 2
-#     good_feature_dir = 2
-#     good_patient_label = 2
-#     good_filename_label = 2
-
-#     # This should raise an error   
-#     slide_df = pd.DataFrame(
-#         slide_path_to_patient.items()
-#     )
-#     assert
-#     slide_to_patient_from_slide_table_(
-#     slide_table_path=bad_slide_table,
-#             feature_dir=bad_feature_dir,
-#             patient_label=bad_patient_label,
-#             filename_label=bad_filename_label,
-# ) 
-#     # This should not raise an error
-#     slide_to_patient_from_slide_table_(
-#     slide_table_path=good_slide_table,
-#             feature_dir=good_feature_dir,
-#             patient_label=good_patient_label,
-#             filename_label=good_filename_label,
-# ) 
+    # Test Good Slide Path using data from create_random_dataset
+    # clini_path, slide_path, feat_dir, categories = create_random_dataset (
+    #     dir= tmp_path,
+    #     n_patients=5,
+    #     max_slides_per_patient=5
+    #     min_tiles_per_slide=1,
+    #     max_tiles_per_slide=5,
+    #     feat_dim=5
+    #     categories=,
+    #     n_categories=2,
+    #     extractor_name=extractor_name;
+    # )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,7 +10,7 @@ from random_data import (
     make_feature_file,
     make_old_feature_file,
     create_good_and_bad_slide_tables,
-    create_random_slide_tables
+    create_random_slide_tables,
 )
 from torch.utils.data import DataLoader
 
@@ -236,34 +236,43 @@ def test_slide_table_h5_validation(tmp_path: Path) -> None:
     # Test with all files having .h5 extensions in filename_label column
     # (should be no error regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
-            slide_table_path=good_slide_path,
-            feature_dir=feature_dir,
-            patient_label="PATIENT",
-            filename_label="FILENAME")
+        slide_table_path=good_slide_path,
+        feature_dir=feature_dir,
+        patient_label="PATIENT",
+        filename_label="FILENAME",
+    )
     assert isinstance(result, dict)
     # Test without any .h5 extensions in filename_label column
-    with pytest.raises(ValueError,
-                       match="One or more files are missing the .h5 extension "
-                       "in the filename_label column. The first file missing "
-                       "the .h5 extension is: slide1.jpg"):
+    with pytest.raises(
+        ValueError,
+        match="One or more files are missing the .h5 extension "
+        "in the filename_label column. The first file missing "
+        "the .h5 extension is: slide1.jpg",
+    ):
         slide_to_patient_from_slide_table_(
             slide_table_path=bad_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
-            filename_label="FILENAME")
+            filename_label="FILENAME",
+        )
     # Test with one filename missing .h5 extension
-    with pytest.raises(ValueError,
-                       match="One or more files are missing the .h5 extension "
-                       "in the filename_label column. The first file missing "
-                       "the .h5 extension is: slide3.jpg"):
+    with pytest.raises(
+        ValueError,
+        match="One or more files are missing the .h5 extension "
+        "in the filename_label column. The first file missing "
+        "the .h5 extension is: slide3.jpg",
+    ):
         slide_to_patient_from_slide_table_(
             slide_table_path=one_bad_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
-            filename_label="FILENAME")
+            filename_label="FILENAME",
+        )
 
 
-def test_slide_table_h5_validation_random(tmp_path: Path, ) -> None:
+def test_slide_table_h5_validation_random(
+    tmp_path: Path,
+) -> None:
     """
     Tests that an error is properly raised in
     slide_to_patient_from_slide_table_() when none of items in the
@@ -276,23 +285,27 @@ def test_slide_table_h5_validation_random(tmp_path: Path, ) -> None:
     feature_dir = tmp_path
 
     good_slide_path, bad_slide_path = create_random_slide_tables(
-        n_patients=10,
-        tmp_path=tmp_path)
+        n_patients=10, tmp_path=tmp_path
+    )
     # Test with .h5 extensions in filename_label column (should be no error
     # regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
-            slide_table_path=good_slide_path,
-            feature_dir=feature_dir,
-            patient_label="PATIENT",
-            filename_label="FILENAME")
+        slide_table_path=good_slide_path,
+        feature_dir=feature_dir,
+        patient_label="PATIENT",
+        filename_label="FILENAME",
+    )
     assert isinstance(result, dict)
 
     # Test without .h5 extensions in filename_label column
-    with pytest.raises(ValueError,
-                       match="One or more files are missing the .h5 extension "
-                       "in the filename_label column"):
+    with pytest.raises(
+        ValueError,
+        match="One or more files are missing the .h5 extension "
+        "in the filename_label column",
+    ):
         slide_to_patient_from_slide_table_(
             slide_table_path=bad_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
-            filename_label="FILENAME")
+            filename_label="FILENAME",
+        )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -227,23 +227,36 @@ def test_slide_table_h5_validation(tmp_path: Path) -> None:
     """
     feature_dir = tmp_path
 
-    good_slide_path, bad_slide_path = create_good_and_bad_slide_tables(
-        tmp_path=tmp_path)
+    (good_slide_path, bad_slide_path, one_bad_slide_path,
+     no_file_names_slide_path) = create_good_and_bad_slide_tables(
+         tmp_path=tmp_path
+    )
 
-    # Test with .h5 extensions in filename_label column (should be no error
-    # regarding no .h5 extensions)
+    # Test with all files having .h5 extensions in filename_label column
+    # (should be no error regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
             slide_table_path=good_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
             filename_label="FILENAME")
     assert isinstance(result, dict)
-    # Test without .h5 extensions in filename_label column
+    # Test without any .h5 extensions in filename_label column
     with pytest.raises(ValueError,
-                       match="No .h5 extensions found in the slide table's "
-                       "filename_label column"):
+                       match="One or more files are missing the .h5 extension "
+                       "in the filename_label column. The first file missing "
+                       "the .h5 extension is: slide1.jpg"):
         slide_to_patient_from_slide_table_(
             slide_table_path=bad_slide_path,
+            feature_dir=feature_dir,
+            patient_label="PATIENT",
+            filename_label="FILENAME")
+    # Test with one filename missing .h5 extension
+    with pytest.raises(ValueError,
+                       match="One or more files are missing the .h5 extension "
+                       "in the filename_label column. The first file missing "
+                       "the .h5 extension is: slide3.jpg"):
+        slide_to_patient_from_slide_table_(
+            slide_table_path=one_bad_slide_path,
             feature_dir=feature_dir,
             patient_label="PATIENT",
             filename_label="FILENAME")
@@ -275,8 +288,8 @@ def test_slide_table_h5_validation_random(tmp_path: Path, ) -> None:
 
     # Test without .h5 extensions in filename_label column
     with pytest.raises(ValueError,
-                       match="No .h5 extensions found in the slide table's "
-                       "filename_label column"):
+                       match="One or more files are missing the .h5 extension "
+                       "in the filename_label column"):
         slide_to_patient_from_slide_table_(
             slide_table_path=bad_slide_path,
             feature_dir=feature_dir,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -227,10 +227,11 @@ def test_slide_table_h5_validation(tmp_path: Path) -> None:
     """
     feature_dir = tmp_path
 
-    (good_slide_path, bad_slide_path, one_bad_slide_path,
-     no_file_names_slide_path) = create_good_and_bad_slide_tables(
-         tmp_path=tmp_path
-    )
+    (
+        good_slide_path,
+        bad_slide_path,
+        one_bad_slide_path,
+    ) = create_good_and_bad_slide_tables(tmp_path=tmp_path)
 
     # Test with all files having .h5 extensions in filename_label column
     # (should be no error regarding no .h5 extensions)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,7 +10,7 @@ from random_data import (
     make_feature_file,
     make_old_feature_file,
     create_good_and_bad_slide__tables,
-    create_random_dataset
+    create_random_slide_tables
 )
 from torch.utils.data import DataLoader
 
@@ -220,17 +220,16 @@ def test_get_coords_historic_format() -> None:
 def test_slide_table_h5_validation(tmp_path: Path):
     """
     Tests that an error is properly raised in
-    slide_to_patient_from_slide_table_( when none of items in the
+    slide_to_patient_from_slide_table_() when none of items in the
     filename_labels column of a slide table have an .h5 extension and
-    verifies that the error isn't raised when
-    
+    verifies that the error isn't raised when there is at least one
+    filename with a .h5 extension in the filename_labels column.
     """
     feature_dir = tmp_path
 
     good_slide_path, bad_slide_path = create_good_and_bad_slide__tables(
         tmp_path=tmp_path)
-    # remember that PandasLabel is just a string
-
+    
     # Test with .h5 extensions in filename_label column (should be no error
     # regarding no .h5 extensions)
     result = slide_to_patient_from_slide_table_(
@@ -249,22 +248,37 @@ def test_slide_table_h5_validation(tmp_path: Path):
             patient_label="PATIENT",
             filename_label="FILENAME")
 
-# def test_slide_table_h5_validation_random(tmp_path: Path, ):
-#     """
-#     Test that an error is raised in 
-#     slide_to_patient_from_slide_table_() when no .h5 files are in the slide
-#     table.
-#     """
 
-    # Test Good Slide Path using data from create_random_dataset
-    # clini_path, slide_path, feat_dir, categories = create_random_dataset (
-    #     dir= tmp_path,
-    #     n_patients=5,
-    #     max_slides_per_patient=5
-    #     min_tiles_per_slide=1,
-    #     max_tiles_per_slide=5,
-    #     feat_dim=5
-    #     categories=,
-    #     n_categories=2,
-    #     extractor_name=extractor_name;
-    # )
+def test_slide_table_h5_validation_random(tmp_path: Path, ):
+    """
+    Tests that an error is properly raised in
+    slide_to_patient_from_slide_table_() when none of items in the
+    filename_labels column of a slide table have an .h5 extension and
+    verifies that the error isn't raised when there is at least one
+    filename with a .h5 extension in the filename_labels column.
+    Uses random data.
+    """
+
+    feature_dir = tmp_path
+
+    good_slide_path, bad_slide_path = create_random_slide_tables(
+        n_patients=10,
+        tmp_path=tmp_path)
+
+    # Test with .h5 extensions in filename_label column (should be no error
+    # regarding no .h5 extensions)
+    result = slide_to_patient_from_slide_table_(
+            slide_table_path=good_slide_path,
+            feature_dir=feature_dir,
+            patient_label="PATIENT",
+            filename_label="FILENAME")
+    assert isinstance(result, dict)
+    # Test without .h5 extensions in filename_label column
+    with pytest.raises(ValueError,
+                       match="No .h5 extensions found in the slide table's "
+                       "filename_label column"):
+        slide_to_patient_from_slide_table_(
+            slide_table_path=bad_slide_path,
+            feature_dir=feature_dir,
+            patient_label="PATIENT",
+            filename_label="FILENAME")


### PR DESCRIPTION
## Description 

Added validation to ensure that slide tables contain at least one feature path with `.h5` extension as per the discussion between @EzicStar and I in Issue #95. 

Note: Shortly before preparing this PR I realized that Issue #95 could be interpreted differently than  I did - if the desire was to have an error raised if ANY filename in the filename_label column lacked an .h5 extension (meaning that ALL filenames in that column must have an `.h5` extension) I should be able to relatively quickly change my code and modify the tests I made. Please let me know if that is the case and I will get on it.



## Changes Made

- Added `.h5` extension validation in `slide_to_patient_from_slide_table_()`  function in scr/stamp/modeling/data.py
-  Raises `ValueError` with a clear message when no files have `.h5` extension in the slide table's `filename_label` column
- Updated Docstring comment for `slide_to_patient_from_slide_table_()` 
- Added helper functions for creating test slide tables in tests/random_data.py

## Testing

- In tests/test_data.py added manual and slightly randomized tests to verify both success and error cases
- All existing tests I'm able to run without access to "gated repos" continue to pass unless skipped, and to the best of my knowledge those tests in test_encoders.py and test_feature_extractors.py that are skipped or fail because of lack of access do not involve data.py 

Resolves #95

