### PR TITLE
support preprocess files from list and add training sample count

### DIFF
--- a/src/stamp/__main__.py
+++ b/src/stamp/__main__.py
@@ -70,6 +70,7 @@ def _run_cli(args: argparse.Namespace) -> None:
             extract_(
                 output_dir=config.preprocessing.output_dir,
                 wsi_dir=config.preprocessing.wsi_dir,
+                wsi_list=config.preprocessing.wsi_list,
                 cache_dir=config.preprocessing.cache_dir,
                 tile_size_um=config.preprocessing.tile_size_um,
                 tile_size_px=config.preprocessing.tile_size_px,

--- a/src/stamp/config.yaml
+++ b/src/stamp/config.yaml
@@ -38,6 +38,10 @@ preprocessing:
   # Used to distinguish features extracted with different code versions.
   #generate_hash: True
 
+  # A list (.txt, .xlsx or .csv) specifying filenames to preprocess 
+  # instead of processing all data in the directory.
+  #wsi_list: "list.csv"
+
 
 crossval:
   output_dir: "/path/to/save/files/to"

--- a/src/stamp/modeling/train.py
+++ b/src/stamp/modeling/train.py
@@ -230,6 +230,9 @@ def setup_dataloaders_for_training(
     Returns:
         train_dl, valid_dl, categories, feature_dim, train_patients, valid_patients
     """
+    # Sample count for training
+    log_total_class_summary(patient_to_data, categories=categories)
+
     # Stratified split
     ground_truths = [
         patient_data.ground_truth
@@ -397,3 +400,18 @@ def _compute_class_weights_and_check_categories(
             "You may want to consider removing these categories; the model will likely overfit on the few samples available."
         )
     return category_weights
+
+def log_total_class_summary(patient_to_data, categories=None):
+    from collections import Counter
+
+    ground_truths = [
+        patient_data.ground_truth
+        for patient_data in patient_to_data.values()
+        if patient_data.ground_truth is not None
+    ]
+    cats = categories or sorted(set(ground_truths))
+    counter = Counter(ground_truths)
+    _logger.info(
+        f"Total samples: {len(ground_truths)} | "
+        + " | ".join([f"Class {cls}: {counter.get(cls, 0)}" for cls in cats])
+    )

--- a/src/stamp/preprocessing/__init__.py
+++ b/src/stamp/preprocessing/__init__.py
@@ -9,6 +9,7 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 import openslide
+import pandas as pd
 import torch
 from PIL import Image
 from torch import Tensor
@@ -129,6 +130,7 @@ def extract_(
     brightness_cutoff: int | None,
     canny_cutoff: float | None,
     generate_hash: bool,
+    wsi_list: Path | None = None,
 ) -> None:
     """
     Extracts features from slides.
@@ -248,11 +250,33 @@ def extract_(
 
     feat_output_dir = output_dir / extractor_id
 
-    slide_paths = [
-        slide_path
-        for extension in supported_extensions
-        for slide_path in wsi_dir.glob(f"**/*{extension}")
-    ]
+    if wsi_list is not None and wsi_list.exists():
+        suf = wsi_list.suffix.lower()
+        if suf == ".txt":
+            with open(wsi_list) as f:
+                allowed_files = set(line.strip() for line in f if line.strip())
+        elif suf in [".csv", ".xls", ".xlsx"]:
+            df = (
+                pd.read_csv(wsi_list, header=None)
+                if suf == ".csv"
+                else pd.read_excel(wsi_list, header=None)
+            )
+            allowed_files = set(df.iloc[:, 0].astype(str))
+        else:
+            raise ValueError(f"Unsupported file type: {suf}")
+
+        slide_paths = [
+            slide_path
+            for ext in supported_extensions
+            for slide_path in wsi_dir.glob(f"**/*{ext}")
+            if slide_path.name in allowed_files
+        ]
+    else:
+        slide_paths = [
+            slide_path
+            for ext in supported_extensions
+            for slide_path in wsi_dir.glob(f"**/*{ext}")
+        ]
     # We shuffle so if we run multiple jobs on multiple computers at the same time,
     # They won't interfere with each other too much
     shuffle(slide_paths)

--- a/src/stamp/preprocessing/config.py
+++ b/src/stamp/preprocessing/config.py
@@ -36,6 +36,7 @@ class PreprocessingConfig(BaseModel, arbitrary_types_allowed=True):
 
     output_dir: Path
     wsi_dir: Path
+    wsi_list: Path = Field(description="Txt, Excel or CSV to read data filename from")
     cache_dir: Path | None = None
     cache_tiles_ext: ImageExtension = "jpg"
     tile_size_um: Microns = Microns(256.0)


### PR DESCRIPTION
Support preprocessing only files specified in a list (.txt, .csv, .xls or .xlsx).
Add the script logs the number of training samples identified, for data tracking.