### PR TITLE
recursive WSI file scan using rglob

### DIFF
--- a/src/stamp/preprocessing/__init__.py
+++ b/src/stamp/preprocessing/__init__.py
@@ -256,7 +256,7 @@ def extract_(
         slide_paths = [wsi_dir / slide for slide in slide_paths]
     else:
         slide_paths = [
-            p for ext in supported_extensions for p in wsi_dir.glob(f"**/*{ext}")
+            p for ext in supported_extensions for p in wsi_dir.rglob(f"*{ext}")
         ]
 
     # We shuffle so if we run multiple jobs on multiple computers at the same time,


### PR DESCRIPTION
Update to use rglob to get the WSI files from all subfolders.
[[View source line](https://github.com/mducducd/STAMP/blob/fix/recursive-wsi-scan/src/stamp/preprocessing/__init__.py#L42)](https://github.com/mducducd/STAMP/blob/b90a78758bf2512b6e37c462c847346f724e8408/src/stamp/preprocessing/__init__.py#L259)