### PR TITLE
Add global random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,9 @@ uv pip install "git+https://github.com/KatherLab/STAMP.git[build,gpu] --no-build
 uv sync --extra build
 uv sync --extra build --extra gpu
 ```
+
+## Reproducibility
+
+We use a central `Seed` utility to set seeds for PyTorch, NumPy, and Python’s `random`. This makes data loading and model initialization reproducible. Always call `Seed.set(seed)` once at startup.
+
+We do not enable [`torch.use_deterministic_algorithms()`](https://pytorch.org/docs/stable/notes/randomness.html#reproducibility) because it can cause large performance drops. Expect runs with the same seed to follow the same training trajectory, but not bit-for-bit identical low-level kernels.

--- a/src/stamp/__main__.py
+++ b/src/stamp/__main__.py
@@ -13,6 +13,7 @@ from stamp.modeling.config import (
     ModelParams,
     VitModelParams,
 )
+from stamp.seed import Seed
 
 STAMP_FACTORY_SETTINGS = Path(__file__).with_name("config.yaml")
 
@@ -48,6 +49,10 @@ def _run_cli(args: argparse.Namespace) -> None:
     # Load YAML configuration
     with open(args.config_file_path, "r") as config_yaml:
         config = StampConfig.model_validate(yaml.safe_load(config_yaml))
+
+    if config.advanced_config is None:
+        config.advanced_config = AdvancedConfig()
+    Seed.set(config.advanced_config.seed)
 
     match args.command:
         case "init":

--- a/src/stamp/__main__.py
+++ b/src/stamp/__main__.py
@@ -51,7 +51,9 @@ def _run_cli(args: argparse.Namespace) -> None:
         config = StampConfig.model_validate(yaml.safe_load(config_yaml))
 
     if config.advanced_config is None:
-        config.advanced_config = AdvancedConfig()
+        config.advanced_config = AdvancedConfig(
+            model_params=ModelParams(vit=VitModelParams(), mlp=MlpModelParams())
+        )
     Seed.set(config.advanced_config.seed)
 
     match args.command:

--- a/src/stamp/config.yaml
+++ b/src/stamp/config.yaml
@@ -277,6 +277,7 @@ patient_encoding:
 
 
 advanced_config:
+  seed: 42
   max_epochs: 32
   patience: 16
   batch_size: 64

--- a/src/stamp/config.yaml
+++ b/src/stamp/config.yaml
@@ -277,7 +277,8 @@ patient_encoding:
 
 
 advanced_config:
-  seed: 42
+  # Optional random seed
+  # seed: 42
   max_epochs: 32
   patience: 16
   batch_size: 64

--- a/src/stamp/modeling/config.py
+++ b/src/stamp/modeling/config.py
@@ -97,4 +97,5 @@ class AdvancedConfig(BaseModel):
         default=None,
         description='Optional: "vit" or "mlp". Defaults based on feature type.',
     )
-    model_params: ModelParams
+    model_params: ModelParams | None = None
+    seed: int = 42

--- a/src/stamp/modeling/config.py
+++ b/src/stamp/modeling/config.py
@@ -97,5 +97,5 @@ class AdvancedConfig(BaseModel):
         default=None,
         description='Optional: "vit" or "mlp". Defaults based on feature type.',
     )
-    model_params: ModelParams | None = None
+    model_params: ModelParams | None
     seed: int = 42

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import KW_ONLY, dataclass
 from itertools import groupby
 from pathlib import Path
-from typing import IO, BinaryIO, Generic, TextIO, TypeAlias, cast, Union
+from typing import IO, BinaryIO, Generic, TextIO, TypeAlias, Union, cast
 
 import h5py
 import numpy as np
@@ -17,6 +17,7 @@ from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
 import stamp
+from stamp.seed import Seed
 from stamp.types import (
     Bags,
     BagSize,
@@ -100,6 +101,8 @@ def tile_bag_dataloader(
                 shuffle=shuffle,
                 num_workers=num_workers,
                 collate_fn=_collate_to_tuple,
+                worker_init_fn=Seed.get_loader_worker_init(),
+                generator=Seed.get_torch_generator(),
             ),
         ),
         list(categories),

--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -101,8 +101,10 @@ def tile_bag_dataloader(
                 shuffle=shuffle,
                 num_workers=num_workers,
                 collate_fn=_collate_to_tuple,
-                worker_init_fn=Seed.get_loader_worker_init(),
-                generator=Seed.get_torch_generator(),
+                worker_init_fn=Seed.get_loader_worker_init()
+                if Seed._is_set()
+                else None,
+                generator=Seed.get_torch_generator() if Seed._is_set() else None,
             ),
         ),
         list(categories),

--- a/src/stamp/seed.py
+++ b/src/stamp/seed.py
@@ -1,0 +1,52 @@
+import random
+from typing import Callable
+
+import numpy as np
+import torch
+from torch import Generator
+
+
+class Seed:
+    seed: int
+
+    @classmethod
+    def torch(cls, seed: int) -> None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+
+    @classmethod
+    def python(cls, seed: int) -> None:
+        random.seed(seed)
+
+    @classmethod
+    def numpy(cls, seed: int) -> None:
+        np.random.seed(seed)
+
+    @classmethod
+    def set(cls, seed: int) -> None:
+        cls.torch(seed)
+        cls.python(seed)
+        cls.numpy(seed)
+        cls.seed = seed
+
+    @classmethod
+    def _is_set(cls) -> bool:
+        return cls.seed is not None
+
+    @classmethod
+    def get_loader_worker_init(cls) -> Callable[[int], None]:
+        def seed_worker(worker_id):
+            worker_seed = torch.initial_seed() % 2**32
+            np.random.seed(worker_seed)
+            random.seed(worker_seed)
+
+        if cls._is_set():
+            return seed_worker
+        else:
+            return lambda x: None
+
+    @classmethod
+    def get_torch_generator(cls, device="cpu") -> Generator:
+        g = torch.Generator(device)
+        g.manual_seed(cls.seed)
+        return g

--- a/src/stamp/seed.py
+++ b/src/stamp/seed.py
@@ -1,5 +1,5 @@
 import random
-from typing import Callable
+from typing import Callable, ClassVar
 
 import numpy as np
 import torch
@@ -13,7 +13,7 @@ def _seed_worker(worker_id: int) -> None:
 
 
 class Seed:
-    seed: int
+    seed: ClassVar[int | None] = None
 
     @classmethod
     def torch(cls, seed: int) -> None:
@@ -50,10 +50,11 @@ class Seed:
 
     @classmethod
     def get_torch_generator(cls, device="cpu") -> Generator:
-        if not cls._is_set():
+        seed = cls.seed
+        if seed is None:
             raise RuntimeError(
                 "Seed has not been set. Call Seed.set(seed) before requesting a generator."
             )
         g = torch.Generator(device)
-        g.manual_seed(cls.seed)
+        g.manual_seed(seed)
         return g

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -45,8 +45,6 @@ def create_random_dataset(
     feat_dir = dir / "feats"
     feat_dir.mkdir()
 
-    Seed.set(42)
-
     if categories is not None:
         if n_categories is not None:
             raise ValueError("only one of `categories` and `n_categories` can be set")

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -16,18 +16,12 @@ from torch import Tensor
 
 import stamp
 from stamp.preprocessing.config import ExtractorName
+from stamp.seed import Seed
 from stamp.types import Category, FeaturePath, Microns, PatientId, TilePixels
 
 CliniPath: TypeAlias = Path
 SlidePath: TypeAlias = Path
 FeatureDir: TypeAlias = Path
-
-
-def seed_rng(seed: int) -> None:
-    """Seeds all the random number generators"""
-    random.seed(seed)
-    torch.manual_seed(seed)
-    np.random.seed(seed)
 
 
 def create_random_dataset(
@@ -50,6 +44,8 @@ def create_random_dataset(
 
     feat_dir = dir / "feats"
     feat_dir.mkdir()
+
+    Seed.set(42)
 
     if categories is not None:
         if n_categories is not None:

--- a/tests/random_data.py
+++ b/tests/random_data.py
@@ -16,7 +16,6 @@ from torch import Tensor
 
 import stamp
 from stamp.preprocessing.config import ExtractorName
-from stamp.seed import Seed
 from stamp.types import Category, FeaturePath, Microns, PatientId, TilePixels
 
 CliniPath: TypeAlias = Path

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -1,8 +1,6 @@
 import os
-import random
 from pathlib import Path
 
-import numpy as np
 import pytest
 import torch
 from random_data import create_random_dataset, create_random_patient_level_dataset
@@ -15,6 +13,7 @@ from stamp.modeling.config import (
     VitModelParams,
 )
 from stamp.modeling.crossval import categorical_crossval_
+from stamp.seed import Seed
 
 
 @pytest.mark.slow
@@ -32,9 +31,7 @@ def test_crossval_integration(
     use_alibi: bool = False,
     use_vary_precision_transform: bool = False,
 ) -> None:
-    random.seed(0)
-    torch.manual_seed(0)
-    np.random.seed(0)
+    Seed.set(42)
 
     if feature_type == "tile":
         clini_path, slide_path, feature_dir, categories = create_random_dataset(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -13,6 +13,7 @@ from stamp.modeling.data import (
 from stamp.modeling.deploy import _predict, _to_prediction_df
 from stamp.modeling.lightning_model import LitVisionTransformer
 from stamp.modeling.mlp_classifier import LitMLPClassifier
+from stamp.seed import Seed
 from stamp.types import GroundTruth, PatientId
 
 
@@ -25,6 +26,7 @@ def test_predict(
     n_heads: int = 7,
     dim_input: int = 12,
 ) -> None:
+    Seed.set(42)
     model = LitVisionTransformer(
         categories=list(categories),
         category_weights=torch.rand(len(categories)),

--- a/tests/test_deployment_backward_compatibility.py
+++ b/tests/test_deployment_backward_compatibility.py
@@ -5,6 +5,7 @@ from stamp.cache import download_file
 from stamp.modeling.data import PatientData, tile_bag_dataloader
 from stamp.modeling.deploy import _predict
 from stamp.modeling.lightning_model import LitVisionTransformer
+from stamp.seed import Seed
 from stamp.types import FeaturePath, PatientId
 
 
@@ -12,6 +13,7 @@ from stamp.types import FeaturePath, PatientId
     "ignore:The 'predict_dataloader' does not have many workers"
 )
 def test_backwards_compatibility() -> None:
+    Seed.set(42)
     example_checkpoint_path = download_file(
         url="https://github.com/KatherLab/STAMP/releases/download/2.2.0/example-model-v2_3_0.ckpt",
         file_name="example-modelv2_3_0.ckpt",

--- a/tests/test_train_deploy.py
+++ b/tests/test_train_deploy.py
@@ -16,6 +16,7 @@ from stamp.modeling.config import (
 )
 from stamp.modeling.deploy import deploy_categorical_model_
 from stamp.modeling.train import train_categorical_model_
+from stamp.seed import Seed
 
 
 @pytest.mark.slow
@@ -35,9 +36,7 @@ def test_train_deploy_integration(
     use_alibi: bool,
     use_vary_precision_transform: bool,
 ) -> None:
-    random.seed(0)
-    torch.manual_seed(0)
-    np.random.seed(0)
+    Seed.set(42)
 
     (tmp_path / "train").mkdir()
     (tmp_path / "deploy").mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -3664,7 +3664,7 @@ wheels = [
 
 [[package]]
 name = "stamp"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Add a Seed utility class to simplify and unify random seed management across PyTorch, NumPy, and Python’s random. It provides methods to set global seeds and initialize DataLoader workers reproducibly. Now available in advanced_config in config.yaml.