### PR TITLE
Fix: allow no random seed

### DIFF
--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -101,8 +101,10 @@ def tile_bag_dataloader(
                 shuffle=shuffle,
                 num_workers=num_workers,
                 collate_fn=_collate_to_tuple,
-                worker_init_fn=Seed.get_loader_worker_init(),
-                generator=Seed.get_torch_generator(),
+                worker_init_fn=Seed.get_loader_worker_init()
+                if Seed._is_set()
+                else None,
+                generator=Seed.get_torch_generator() if Seed._is_set() else None,
             ),
         ),
         list(categories),

--- a/src/stamp/seed.py
+++ b/src/stamp/seed.py
@@ -52,9 +52,7 @@ class Seed:
     def get_torch_generator(cls, device="cpu") -> Generator:
         seed = cls.seed
         if seed is None:
-            raise RuntimeError(
-                "Seed has not been set. Call Seed.set(seed) before requesting a generator."
-            )
+            raise RuntimeError("Seed has not been set.")
         g = torch.Generator(device)
         g.manual_seed(seed)
         return g


### PR DESCRIPTION
Stamp should allow no random seed by default; the last merge has missed this.