### PR TITLE
Fix/encode check

### DIFF
--- a/src/stamp/encoding/__init__.py
+++ b/src/stamp/encoding/__init__.py
@@ -54,7 +54,7 @@ def init_slide_encoder_(
 
             selected_encoder: Encoder = Gigapath()
 
-        case EncoderName.CHIEF:
+        case EncoderName.CHIEF_CTRANSPATH:
             from stamp.encoding.encoder.chief import CHIEF
 
             selected_encoder: Encoder = CHIEF()
@@ -140,7 +140,7 @@ def init_patient_encoder_(
 
             selected_encoder: Encoder = Gigapath()
 
-        case EncoderName.CHIEF:
+        case EncoderName.CHIEF_CTRANSPATH:
             from stamp.encoding.encoder.chief import CHIEF
 
             selected_encoder: Encoder = CHIEF()

--- a/src/stamp/encoding/config.py
+++ b/src/stamp/encoding/config.py
@@ -9,7 +9,7 @@ from stamp.types import DeviceLikeType, PandasLabel
 class EncoderName(StrEnum):
     COBRA = "cobra"
     EAGLE = "eagle"
-    CHIEF = "chief"
+    CHIEF_CTRANSPATH = "chief"
     TITAN = "titan"
     GIGAPATH = "gigapath"
     MADELEINE = "madeleine"

--- a/src/stamp/encoding/encoder/gigapath.py
+++ b/src/stamp/encoding/encoder/gigapath.py
@@ -129,7 +129,16 @@ class Gigapath(Encoder):
                 slide_filename = row[filename_label]
                 h5_path = os.path.join(feat_dir, slide_filename)
 
-                feats, coords = self._validate_and_read_features(h5_path=h5_path)
+                # Skip if not an .h5 file
+                if not h5_path.endswith(".h5"):
+                    tqdm.write(f"Skipping {slide_filename} (not an .h5 file)")
+                    continue
+
+                try:
+                    feats, coords = self._validate_and_read_features(h5_path=h5_path)
+                except (FileNotFoundError, ValueError, OSError) as e:
+                    tqdm.write(f"Skipping {slide_filename}: {e}")
+                    continue
 
                 # Get the mpp of one slide and check that the rest have the same
                 if slides_mpp < 0:

--- a/src/stamp/encoding/encoder/titan.py
+++ b/src/stamp/encoding/encoder/titan.py
@@ -134,7 +134,16 @@ class Titan(Encoder):
                 slide_filename = row[filename_label]
                 h5_path = os.path.join(feat_dir, slide_filename)
 
-                feats, coords = self._validate_and_read_features(h5_path=h5_path)
+                # Skip if not an .h5 file
+                if not h5_path.endswith(".h5"):
+                    tqdm.write(f"Skipping {slide_filename} (not an .h5 file)")
+                    continue
+
+                try:
+                    feats, coords = self._validate_and_read_features(h5_path=h5_path)
+                except (FileNotFoundError, ValueError, OSError) as e:
+                    tqdm.write(f"Skipping {slide_filename}: {e}")
+                    continue
 
                 # Get the mpp of one slide and check that the rest have the same
                 if slides_mpp < 0:

--- a/src/stamp/preprocessing/__init__.py
+++ b/src/stamp/preprocessing/__init__.py
@@ -240,15 +240,16 @@ def extract_(
 
     extractor_id = extractor.identifier
 
-    if generate_hash:
-        extractor_id += f"-{code_hash}"
-
     _logger.info(f"Using extractor {extractor.identifier}")
 
     if cache_dir:
         cache_dir.mkdir(parents=True, exist_ok=True)
 
-    feat_output_dir = output_dir / extractor_id
+    feat_output_dir = (
+        output_dir / f"{extractor_id}-{code_hash}"
+        if generate_hash
+        else output_dir / extractor_id
+    )
 
     # Collect slides for preprocessing
     if wsi_list is not None:

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -33,7 +33,7 @@ input_dims = {
 
 # They are not all, just one case that is accepted for each encoder
 used_extractor = {
-    EncoderName.CHIEF: ExtractorName.CHIEF_CTRANSPATH,
+    EncoderName.CHIEF_CTRANSPATH: ExtractorName.CHIEF_CTRANSPATH,
     EncoderName.COBRA: ExtractorName.CONCH,
     EncoderName.EAGLE: ExtractorName.CTRANSPATH,
     EncoderName.GIGAPATH: ExtractorName.GIGAPATH,
@@ -73,7 +73,7 @@ def test_if_encoding_crashes(*, tmp_path: Path, encoder: EncoderName):
     )
 
     cuda_required = [
-        EncoderName.CHIEF,
+        EncoderName.CHIEF_CTRANSPATH,
         EncoderName.COBRA,
         EncoderName.GIGAPATH,
         EncoderName.MADELEINE,
@@ -103,6 +103,28 @@ def test_if_encoding_crashes(*, tmp_path: Path, encoder: EncoderName):
                 max_tiles=32,
                 feat_dim=input_dims[ExtractorName.VIRCHOW2],
                 extractor_name=ExtractorName.VIRCHOW2,
+                feat_filename=feat_filename,
+                coords=coords,
+            )
+    elif encoder == EncoderName.PRISM:
+        # Eagle requires the aggregated features, so we generate new ones
+        # with same name and coordinates as the other ctranspath feats.
+        agg_feat_dir = tmp_path / "agg_output"
+        agg_feat_dir.mkdir()
+        slide_df = pd.read_csv(slide_path)
+        feature_filenames = [Path(path).stem for path in slide_df["slide_path"]]
+
+        for feat_filename in feature_filenames:
+            # Read the coordinates from the ctranspath feature file
+            ctranspath_file = feature_dir / f"{feat_filename}.h5"
+            with h5py.File(ctranspath_file, "r") as h5_file:
+                coords: np.ndarray = h5_file["coords"][:]  # type: ignore
+            create_random_feature_file(
+                tmp_path=agg_feat_dir,
+                min_tiles=32,
+                max_tiles=32,
+                feat_dim=input_dims[ExtractorName.VIRCHOW_FULL],
+                extractor_name="virchow-full",
                 feat_filename=feat_filename,
                 coords=coords,
             )


### PR DESCRIPTION
Fixed issues as follows:
- .h5 feature files now are saved with the corrected extractor name (e.g, gigapth not gigapath-221g42), the old code accidentally saved extractor-hashcod. However, a resolve function was added to accept features from previous stamp versions.
- For patient encoding, auto-skip patients that don't have features instead of breaking the process as before.