### PR TITLE
robust slide_names: handle slide_names with multiple dots

### DIFF
--- a/src/stamp/encoding/encoder/__init__.py
+++ b/src/stamp/encoding/encoder/__init__.py
@@ -62,7 +62,7 @@ class Encoder(ABC):
 
         for tile_feats_filename in (progress := tqdm(os.listdir(feat_dir))):
             h5_path = os.path.join(feat_dir, tile_feats_filename)
-            slide_name: str = Path(tile_feats_filename).stem
+            slide_name: str = Path(tile_feats_filename).name
             progress.set_description(slide_name)
 
             # skip patient in case feature file already exists


### PR DESCRIPTION
- Previously: Path.stem on files like fileA.someaddition.h5 and fileA.somedifferentaddition.h5 yielded identical slide_names, causing the latter file to be skipped.
- Now: use Path.name to keep the full filename (including all dots) so each tile-features file gets a distinct slide_name.