### PR TITLE
fix(eagle): Add robust error handling for missing feature files in patient encoding

### DIFF
--- a/src/stamp/encoding/encoder/eagle.py
+++ b/src/stamp/encoding/encoder/eagle.py
@@ -233,9 +233,6 @@ class Eagle(Encoder):
                     )
                     continue
 
-                # feats, agg_feats = self._validate_and_read_features_with_agg(
-                #     h5_ctp, h5_vir2, slide_name
-                # )
                 feats_list.append(feats)
                 agg_feats_list.append(agg_feats)
 


### PR DESCRIPTION
--fix: 
try-except-block prevents prevent the process from crashing when feature files listed in the slide table are missing or inaccessible.

--background:
>encode_slides_: Iterates over os.listdir(feat_dir). This naturally filters out missing files because it only attempts to process files that the OS reports as present.
>encode_patients_: Iterates over a pandas DataFrame (patient_groups). If the csv contains a reference to a slide filename that does not exist on disk, the direct file access causes a FileNotFoundError or OSError, crashing the entire pipeline