### PR TITLE
Refactor _resolve_extractor_name for better clarity

### DIFF
--- a/src/stamp/encoding/encoder/__init__.py
+++ b/src/stamp/encoding/encoder/__init__.py
@@ -1,5 +1,5 @@
 import logging
-import 
+import os
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -63,7 +63,7 @@ class Encoder(ABC):
 
         for tile_feats_filename in (progress := tqdm(os.listdir(feat_dir))):
             h5_path = os.path.join(feat_dir, tile_feats_filename)
-            slide_name: str = Path(tile_feats_filename).name
+            slide_name: str = Path(tile_feats_filename).stem
             progress.set_description(slide_name)
 
             # skip patient in case feature file already exists


### PR DESCRIPTION
Refactors _resolve_extractor_name to strip the legacy -<hash> suffix accidentally added to ExtractorName by older STAMP versions, for someone who wants to reuse features extracted by STAMPv2.3 and below.
The previous function failed in the case of "conch1_5"