### PR TITLE
Recursively look for feature files to check type

### DIFF
--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -435,7 +435,7 @@ def detect_feature_type(feature_dir: Path) -> str:
     feature_types = set()
     files_checked = 0
 
-    for file in feature_dir.glob("*.h5"):
+    for file in feature_dir.rglob("*.h5"):
         files_checked += 1
         with h5py.File(file, "r") as h5:
             feat_type = h5.attrs.get("feat_type")


### PR DESCRIPTION
# Fix

When generating the features of a set of WSIs in a folder with the following structure:

- wsi_folder
    - patient1
        - pat1_slide1.mrxs
        - pat1_slide2.mrxs
    - patient2
        - pat2_slide1.mrxs
 
the preprocessing pipeline puts the features in the original folder structure. However, when one tries to run cross validation on a task using those features, the pipeline checks for the feature type by inspecting the root folder only. This throws the error:  _"No .h5 feature files found in feature_dir."_. 