### PR TITLE
Fix: missing error handling of ground truth labels with a slash

### DIFF
--- a/src/stamp/modeling/data.py
+++ b/src/stamp/modeling/data.py
@@ -1104,11 +1104,9 @@ def filter_complete_patient_data_(
         )
     }
 
-    _logger.info(
-        f"Total patients in clinical table: {len(patient_to_ground_truth)}\n"
-        f"Patients appearing in slide table: {len(patient_to_slides)}\n"
-        f"Final usable patients (complete data): {len(patients)}\n"
-    )
+    _logger.info("Total patients in clinical table: %d", len(patient_to_ground_truth))
+    _logger.info("Patients appearing in slide table: %d", len(patient_to_slides))
+    _logger.info("Final usable patients (complete data): %d", len(patients))
     return patients
 
 

--- a/src/stamp/modeling/models/cox.py
+++ b/src/stamp/modeling/models/cox.py
@@ -4,7 +4,6 @@ In parts from https://github.com/Novartis/torchsurv/blob/main/src/torchsurv/loss
 # pylint: disable=C0103
 # pylint: disable=C0301
 
-import sys
 import warnings
 
 import torch
@@ -268,15 +267,3 @@ def neg_partial_log_likelihood(
             )
         )
     return loss
-
-
-if __name__ == "__main__":
-    import doctest
-
-    # Run doctest
-    results = doctest.testmod()
-    if results.failed == 0:
-        print("All tests passed.")
-    else:
-        print("Some doctests failed.")
-        sys.exit(1)

--- a/src/stamp/statistics/__init__.py
+++ b/src/stamp/statistics/__init__.py
@@ -30,13 +30,9 @@ from stamp.statistics.roc import (
 )
 from stamp.statistics.survival import _plot_km, _survival_stats_for_csv
 from stamp.types import PandasLabel, Task
+from stamp.utils.path import path_safe
 
 __all__ = ["StatsConfig", "compute_stats_", "path_safe"]
-
-
-def path_safe(label: str) -> str:
-    """Replace '/' (and '\\') with '_' so labels are safe as filename parts."""
-    return label.replace("/", "_").replace("\\", "_")
 
 
 __author__ = "Marko van Treeck, Minh Duc Nguyen"

--- a/src/stamp/statistics/__init__.py
+++ b/src/stamp/statistics/__init__.py
@@ -6,6 +6,7 @@ to the task-specific statistic implementations found in the submodules.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from pathlib import Path
 from typing import NewType
@@ -31,7 +32,20 @@ from stamp.statistics.roc import (
 from stamp.statistics.survival import _plot_km, _survival_stats_for_csv
 from stamp.types import PandasLabel, Task
 
-__all__ = ["StatsConfig", "compute_stats_"]
+__all__ = ["StatsConfig", "compute_stats_", "path_safe"]
+
+
+_PATH_SEP_RE = re.compile(r"[/\\]+")
+
+
+def path_safe(label: str) -> str:
+    """Make a label safe to embed in a filename.
+
+    Replaces path separators with ``_`` so labels like
+    ``"Parameter(0=mod/well,1=poor)"`` don't get interpreted as a
+    subdirectory when passed to ``pathlib.Path``.
+    """
+    return _PATH_SEP_RE.sub("_", label)
 
 
 __author__ = "Marko van Treeck, Minh Duc Nguyen"
@@ -146,7 +160,8 @@ def _compute_multitarget_classification_stats(
                 )
 
             fig.tight_layout()
-            fig.savefig(output_dir / f"roc-curve_{target_label}={true_class}.svg")
+            safe_target = path_safe(target_label)
+            fig.savefig(output_dir / f"roc-curve_{safe_target}={true_class}.svg")
             plt.close(fig)
 
             # Plot PRC curve
@@ -172,7 +187,7 @@ def _compute_multitarget_classification_stats(
                 )
 
             fig.tight_layout()
-            fig.savefig(output_dir / f"pr-curve_{target_label}={true_class}.svg")
+            fig.savefig(output_dir / f"pr-curve_{safe_target}={true_class}.svg")
             plt.close(fig)
 
     # Compute aggregated statistics for all targets
@@ -291,9 +306,8 @@ def compute_stats_(
 
                 fig.tight_layout()
                 output_dir.mkdir(parents=True, exist_ok=True)
-                fig.savefig(
-                    output_dir / f"roc-curve_{ground_truth_label}={true_class}.svg"
-                )
+                safe_label = path_safe(ground_truth_label)
+                fig.savefig(output_dir / f"roc-curve_{safe_label}={true_class}.svg")
                 plt.close(fig)
 
                 fig, ax = plt.subplots(
@@ -320,9 +334,7 @@ def compute_stats_(
                     )
 
                 fig.tight_layout()
-                fig.savefig(
-                    output_dir / f"pr-curve_{ground_truth_label}={true_class}.svg"
-                )
+                fig.savefig(output_dir / f"pr-curve_{safe_label}={true_class}.svg")
                 plt.close(fig)
 
                 categorical_aggregated_(

--- a/src/stamp/statistics/__init__.py
+++ b/src/stamp/statistics/__init__.py
@@ -6,7 +6,6 @@ to the task-specific statistic implementations found in the submodules.
 
 from __future__ import annotations
 
-import re
 from collections.abc import Sequence
 from pathlib import Path
 from typing import NewType
@@ -35,17 +34,9 @@ from stamp.types import PandasLabel, Task
 __all__ = ["StatsConfig", "compute_stats_", "path_safe"]
 
 
-_PATH_SEP_RE = re.compile(r"[/\\]+")
-
-
 def path_safe(label: str) -> str:
-    """Make a label safe to embed in a filename.
-
-    Replaces path separators with ``_`` so labels like
-    ``"Parameter(0=mod/well,1=poor)"`` don't get interpreted as a
-    subdirectory when passed to ``pathlib.Path``.
-    """
-    return _PATH_SEP_RE.sub("_", label)
+    """Replace '/' (and '\\') with '_' so labels are safe as filename parts."""
+    return label.replace("/", "_").replace("\\", "_")
 
 
 __author__ = "Marko van Treeck, Minh Duc Nguyen"
@@ -160,8 +151,10 @@ def _compute_multitarget_classification_stats(
                 )
 
             fig.tight_layout()
-            safe_target = path_safe(target_label)
-            fig.savefig(output_dir / f"roc-curve_{safe_target}={true_class}.svg")
+            fig.savefig(
+                output_dir
+                / f"roc-curve_{path_safe(target_label)}={true_class}.svg"
+            )
             plt.close(fig)
 
             # Plot PRC curve
@@ -187,7 +180,9 @@ def _compute_multitarget_classification_stats(
                 )
 
             fig.tight_layout()
-            fig.savefig(output_dir / f"pr-curve_{safe_target}={true_class}.svg")
+            fig.savefig(
+                output_dir / f"pr-curve_{path_safe(target_label)}={true_class}.svg"
+            )
             plt.close(fig)
 
     # Compute aggregated statistics for all targets
@@ -306,8 +301,10 @@ def compute_stats_(
 
                 fig.tight_layout()
                 output_dir.mkdir(parents=True, exist_ok=True)
-                safe_label = path_safe(ground_truth_label)
-                fig.savefig(output_dir / f"roc-curve_{safe_label}={true_class}.svg")
+                fig.savefig(
+                    output_dir
+                    / f"roc-curve_{path_safe(ground_truth_label)}={true_class}.svg"
+                )
                 plt.close(fig)
 
                 fig, ax = plt.subplots(
@@ -334,7 +331,10 @@ def compute_stats_(
                     )
 
                 fig.tight_layout()
-                fig.savefig(output_dir / f"pr-curve_{safe_label}={true_class}.svg")
+                fig.savefig(
+                    output_dir
+                    / f"pr-curve_{path_safe(ground_truth_label)}={true_class}.svg"
+                )
                 plt.close(fig)
 
                 categorical_aggregated_(

--- a/src/stamp/statistics/__init__.py
+++ b/src/stamp/statistics/__init__.py
@@ -152,8 +152,7 @@ def _compute_multitarget_classification_stats(
 
             fig.tight_layout()
             fig.savefig(
-                output_dir
-                / f"roc-curve_{path_safe(target_label)}={true_class}.svg"
+                output_dir / f"roc-curve_{path_safe(target_label)}={true_class}.svg"
             )
             plt.close(fig)
 

--- a/src/stamp/statistics/categorical.py
+++ b/src/stamp/statistics/categorical.py
@@ -7,7 +7,7 @@ import pandas as pd
 import scipy.stats as st
 from sklearn import metrics
 
-from stamp.statistics import path_safe
+from stamp.utils.path import path_safe
 
 __author__ = "Marko van Treeck"
 __copyright__ = "Copyright (C) 2022-2025 Marko van Treeck"

--- a/src/stamp/statistics/categorical.py
+++ b/src/stamp/statistics/categorical.py
@@ -7,6 +7,8 @@ import pandas as pd
 import scipy.stats as st
 from sklearn import metrics
 
+from stamp.statistics import path_safe
+
 __author__ = "Marko van Treeck"
 __copyright__ = "Copyright (C) 2022-2025 Marko van Treeck"
 __license__ = "MIT"
@@ -137,9 +139,10 @@ def categorical_aggregated_(
         )
 
     preds_df = pd.concat(preds_dfs).sort_index()
-    preds_df.to_csv(outpath / f"{ground_truth_label}_categorical-stats_individual.csv")
+    safe_label = path_safe(ground_truth_label)
+    preds_df.to_csv(outpath / f"{safe_label}_categorical-stats_individual.csv")
     stats_df = _aggregate_categorical_stats(preds_df.reset_index())
-    stats_df.to_csv(outpath / f"{ground_truth_label}_categorical-stats_aggregated.csv")
+    stats_df.to_csv(outpath / f"{safe_label}_categorical-stats_aggregated.csv")
 
 
 def categorical_aggregated_multitarget_(
@@ -181,11 +184,12 @@ def categorical_aggregated_multitarget_(
 
         # Concatenate and save individual stats for this target
         preds_df = pd.concat(preds_dfs).sort_index()
-        preds_df.to_csv(outpath / f"{target_label}_categorical-stats_individual.csv")
+        safe_target = path_safe(target_label)
+        preds_df.to_csv(outpath / f"{safe_target}_categorical-stats_individual.csv")
 
         # Aggregate stats for this target
         stats_df = _aggregate_categorical_stats(preds_df.reset_index())
-        stats_df.to_csv(outpath / f"{target_label}_categorical-stats_aggregated.csv")
+        stats_df.to_csv(outpath / f"{safe_target}_categorical-stats_aggregated.csv")
 
         # Store for summary
         all_target_stats[target_label] = stats_df

--- a/src/stamp/statistics/categorical.py
+++ b/src/stamp/statistics/categorical.py
@@ -139,10 +139,13 @@ def categorical_aggregated_(
         )
 
     preds_df = pd.concat(preds_dfs).sort_index()
-    safe_label = path_safe(ground_truth_label)
-    preds_df.to_csv(outpath / f"{safe_label}_categorical-stats_individual.csv")
+    preds_df.to_csv(
+        outpath / f"{path_safe(ground_truth_label)}_categorical-stats_individual.csv"
+    )
     stats_df = _aggregate_categorical_stats(preds_df.reset_index())
-    stats_df.to_csv(outpath / f"{safe_label}_categorical-stats_aggregated.csv")
+    stats_df.to_csv(
+        outpath / f"{path_safe(ground_truth_label)}_categorical-stats_aggregated.csv"
+    )
 
 
 def categorical_aggregated_multitarget_(
@@ -184,12 +187,15 @@ def categorical_aggregated_multitarget_(
 
         # Concatenate and save individual stats for this target
         preds_df = pd.concat(preds_dfs).sort_index()
-        safe_target = path_safe(target_label)
-        preds_df.to_csv(outpath / f"{safe_target}_categorical-stats_individual.csv")
+        preds_df.to_csv(
+            outpath / f"{path_safe(target_label)}_categorical-stats_individual.csv"
+        )
 
         # Aggregate stats for this target
         stats_df = _aggregate_categorical_stats(preds_df.reset_index())
-        stats_df.to_csv(outpath / f"{safe_target}_categorical-stats_aggregated.csv")
+        stats_df.to_csv(
+            outpath / f"{path_safe(target_label)}_categorical-stats_aggregated.csv"
+        )
 
         # Store for summary
         all_target_stats[target_label] = stats_df

--- a/src/stamp/statistics/regression.py
+++ b/src/stamp/statistics/regression.py
@@ -109,11 +109,14 @@ def regression_aggregated_(
 
     # Save individual stats and aggregate
     stats_df = pd.DataFrame(stats).transpose()
-    safe_label = path_safe(ground_truth_label)
-    stats_df.to_csv(outpath / f"{safe_label}_regression-stats_individual.csv")
+    stats_df.to_csv(
+        outpath / f"{path_safe(ground_truth_label)}_regression-stats_individual.csv"
+    )
 
     mean = stats_df.mean(numeric_only=True)
     sem = stats_df.sem(numeric_only=True)
     lower, upper = st.t.interval(0.95, len(stats_df) - 1, loc=mean, scale=sem)
     agg = pd.DataFrame({"mean": mean, "95%_low": lower, "95%_high": upper})
-    agg.to_csv(outpath / f"{safe_label}_regression-stats_aggregated.csv")
+    agg.to_csv(
+        outpath / f"{path_safe(ground_truth_label)}_regression-stats_aggregated.csv"
+    )

--- a/src/stamp/statistics/regression.py
+++ b/src/stamp/statistics/regression.py
@@ -10,7 +10,7 @@ import pandas as pd
 import scipy.stats as st
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from stamp.statistics import path_safe
+from stamp.utils.path import path_safe
 
 
 def _regression(preds_df: pd.DataFrame, target_label: str) -> pd.Series:

--- a/src/stamp/statistics/regression.py
+++ b/src/stamp/statistics/regression.py
@@ -10,6 +10,8 @@ import pandas as pd
 import scipy.stats as st
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
+from stamp.statistics import path_safe
+
 
 def _regression(preds_df: pd.DataFrame, target_label: str) -> pd.Series:
     """Compute regression metrics for one prediction table."""
@@ -107,10 +109,11 @@ def regression_aggregated_(
 
     # Save individual stats and aggregate
     stats_df = pd.DataFrame(stats).transpose()
-    stats_df.to_csv(outpath / f"{ground_truth_label}_regression-stats_individual.csv")
+    safe_label = path_safe(ground_truth_label)
+    stats_df.to_csv(outpath / f"{safe_label}_regression-stats_individual.csv")
 
     mean = stats_df.mean(numeric_only=True)
     sem = stats_df.sem(numeric_only=True)
     lower, upper = st.t.interval(0.95, len(stats_df) - 1, loc=mean, scale=sem)
     agg = pd.DataFrame({"mean": mean, "95%_low": lower, "95%_high": upper})
-    agg.to_csv(outpath / f"{ground_truth_label}_regression-stats_aggregated.csv")
+    agg.to_csv(outpath / f"{safe_label}_regression-stats_aggregated.csv")

--- a/src/stamp/utils/path.py
+++ b/src/stamp/utils/path.py
@@ -1,0 +1,6 @@
+"""Small path-related helpers shared across the project."""
+
+
+def path_safe(label: str) -> str:
+    """Replace path separators so labels are safe as filename parts."""
+    return label.replace("/", "_").replace("\\", "_")


### PR DESCRIPTION
- Replace / with _ at every filename-construction site in the statistics phase: ROC/PR curve SVGs (single- and multi-target) and the categorical/regression stats CSVs. #176
- Original label is preserved in CSV columns, plot titles, and config — only the filename component is sanitized.
- Refactor log.info in `data.py` and redundant code in `cox.py`